### PR TITLE
Allow newline differences between expected answer and program output

### DIFF
--- a/tools/tester.py
+++ b/tools/tester.py
@@ -60,13 +60,13 @@ def do_test(exec_file=None):
         if os.path.basename(infile)[2:] != os.path.basename(outfile)[3:]:
             print_e("The output for '%s' is not '%s'!!!" % (infile, outfile))
             raise IrregularInOutFileError
-        with open(infile, "r") as inf, open(outfile, "rb") as ouf:
+        with open(infile, "r") as inf, open(outfile, "r") as ouf:
             ans_data = ouf.read()
             out_data = ""
             status = "WA"
             try:
                 out_data = subprocess.check_output(
-                    [exec_file, ""], stdin=inf, timeout=1)
+                    [exec_file, ""], stdin=inf, universal_newlines=True, timeout=1)
             except subprocess.TimeoutExpired:
                 status = "TLE(1s)"
             except subprocess.CalledProcessError:
@@ -85,10 +85,10 @@ def do_test(exec_file=None):
                     print_e(inf2.read(), end='')
                 print_e("[Expected]")
                 print_e("%s%s%s" %
-                        (OKBLUE, ans_data.decode('utf-8'), ENDC), end='')
+                        (OKBLUE, ans_data, ENDC), end='')
                 print_e("[Received]")
                 print_e("%s%s%s" %
-                        (FAIL, out_data.decode('utf-8'), ENDC), end='')
+                        (FAIL, out_data, ENDC), end='')
                 print_e()
         total += 1
 

--- a/tools/tester.py
+++ b/tools/tester.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-
+import re
 import sys
 import os
 import glob
@@ -40,6 +40,10 @@ def is_executable_file(file_name):
            and file_name.find(".cpp") == -1 and not file_name.endswith(".txt")  # cppやtxtを省くのは一応の Cygwin 対策
 
 
+def remove_last_newline(output):
+    return re.sub(r'\n$', '', output, 1)
+
+
 def do_test(exec_file=None):
     exec_files = [fname for fname in glob.glob('./*') if is_executable_file(fname)]
     if exec_file is None:
@@ -72,7 +76,7 @@ def do_test(exec_file=None):
             except subprocess.CalledProcessError:
                 status = "RE"
 
-            if out_data == ans_data:
+            if remove_last_newline(ans_data) == remove_last_newline(out_data):
                 status = "PASSED"
                 print_e("# %s ... %s" % (os.path.basename(infile),
                                          "%s%s%s" % (OKGREEN, status, ENDC)))

--- a/tools/tester.py
+++ b/tools/tester.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-import re
+
 import sys
 import os
 import glob
@@ -40,10 +40,6 @@ def is_executable_file(file_name):
            and file_name.find(".cpp") == -1 and not file_name.endswith(".txt")  # cppやtxtを省くのは一応の Cygwin 対策
 
 
-def remove_last_newline(output):
-    return re.sub(r'\n$', '', output, 1)
-
-
 def do_test(exec_file=None):
     exec_files = [fname for fname in glob.glob('./*') if is_executable_file(fname)]
     if exec_file is None:
@@ -76,7 +72,7 @@ def do_test(exec_file=None):
             except subprocess.CalledProcessError:
                 status = "RE"
 
-            if remove_last_newline(ans_data) == remove_last_newline(out_data):
+            if out_data == ans_data:
                 status = "PASSED"
                 print_e("# %s ... %s" % (os.path.basename(infile),
                                          "%s%s%s" % (OKGREEN, status, ENDC)))

--- a/tools/tester_test.py
+++ b/tools/tester_test.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from tester import is_executable_file
+from tester import is_executable_file, remove_last_newline
 
 
 class TestTester(unittest.TestCase):
@@ -35,6 +35,15 @@ class TestTester(unittest.TestCase):
     @patch('pathlib.Path.is_file', return_value=False)
     def test_is_executable_file__directory(self, os_mock, is_file_mock):
         self.assertFalse(is_executable_file('directory'))
+
+    def test_remove_last_newline(self):
+        self.assertEqual('ans1\nans2', remove_last_newline('ans1\nans2\n'))
+
+    def test_remove_last_newline__no_newline_at_end(self):
+        self.assertEqual('ans1\nans2', remove_last_newline('ans1\nans2'))
+
+    def test_remove_last_newline__remove_only_one_newline(self):
+        self.assertEqual('ans\n', remove_last_newline('ans\n\n'))
 
 
 if __name__ == '__main__':

--- a/tools/tester_test.py
+++ b/tools/tester_test.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from tester import is_executable_file, remove_last_newline
+from tester import is_executable_file
 
 
 class TestTester(unittest.TestCase):
@@ -35,15 +35,6 @@ class TestTester(unittest.TestCase):
     @patch('pathlib.Path.is_file', return_value=False)
     def test_is_executable_file__directory(self, os_mock, is_file_mock):
         self.assertFalse(is_executable_file('directory'))
-
-    def test_remove_last_newline(self):
-        self.assertEqual('ans1\nans2', remove_last_newline('ans1\nans2\n'))
-
-    def test_remove_last_newline__no_newline_at_end(self):
-        self.assertEqual('ans1\nans2', remove_last_newline('ans1\nans2'))
-
-    def test_remove_last_newline__remove_only_one_newline(self):
-        self.assertEqual('ans\n', remove_last_newline('ans\n\n'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In this pull request, I changed `tester.py` so that

* The tester accepts newline code difference between answer and output. #20 
    * This is accomplished by [Python's universal newline feature](https://www.python.org/dev/peps/pep-0278/) which replaces all newline code (\n, \r, \r\n) into \n.
* ~~The tester accepts one newline difference at the end of answer/output.~~
    * ~~This is accomplished by removing a newline at the end of answer and output.~~