### PR TITLE
hotfix: fix wrong template

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ code_generator_file="~/custom_code_generator.py"
 #include <bits/stdc++.h>
 using namespace std;
 
-{% if mod is not none %}const int mod = {{ mod }};{% endif %}
-{% if yes_str is not none %}const string YES = "{{ yes_str }}";{% endif %}
-{% if no_str is not none %}const string NO = "{{ no_str }}";{% endif %}
+{% if mod %}const int mod = {{ mod }};{% endif %}
+{% if yes_str %}const string YES = "{{ yes_str }}";{% endif %}
+{% if no_str %}const string NO = "{{ no_str }}";{% endif %}
 
 void solve({{formal_arguments}}){
 

--- a/atcodertools/tools/templates/cpp/template_success.cpp
+++ b/atcodertools/tools/templates/cpp/template_success.cpp
@@ -1,9 +1,9 @@
 #include <bits/stdc++.h>
 using namespace std;
 
-{% if mod is defined %}const long long MOD = {{ mod }};{% endif %}
-{% if yes_str is defined %}const string YES = "{{ yes_str }}";{% endif %}
-{% if no_str is defined %}const string NO = "{{ no_str }}";{% endif %}
+{% if mod %}const long long MOD = {{ mod }};{% endif %}
+{% if yes_str %}const string YES = "{{ yes_str }}";{% endif %}
+{% if no_str %}const string NO = "{{ no_str }}";{% endif %}
 
 void solve({{ formal_arguments }}){
 

--- a/atcodertools/tools/templates/java/template_success.java
+++ b/atcodertools/tools/templates/java/template_success.java
@@ -2,9 +2,9 @@ import java.io.*;
 import java.util.*;
 
 class Main {
-	{% if mod %static final long MOD = {{ mod }};{% endif %}
-	{% if yes_str is not none %}static final String YES = "{{ yes_str }}";{% endif %}
-	{% if no_str is not none %}static final String NO = "{{ no_str }}";{% endif %}
+	{% if mod %}static final long MOD = {{ mod }};{% endif %}
+	{% if yes_str %}static final String YES = "{{ yes_str }}";{% endif %}
+	{% if no_str %}static final String NO = "{{ no_str }}";{% endif %}
 
 	public static void main(String[] args) throws Exception {
 		final Scanner sc = new Scanner(System.in);


### PR DESCRIPTION
元々 if XXXというイディオムは分かりにくいという話だったが、実はそれを避けると{% mod is not none and mod is defined %}と書かなければいけなくて、それはさすがに地獄なのでif XXXイディオムを採用する

現状問題なのはこういうのが生成されるところ
```
#include <bits/stdc++.h>
using namespace std;

const long long MOD = None;
const string YES = "None";
const string NO = "None";

void solve(long long N, vector<long long> h){

}

int main(){
    long long N;
    scanf("%lld",&N);
    vector<long long> h(N);
    for(int i = 0 ; i < N ; i++){
        scanf("%lld",&h[i]);
    }
    solve(N, h);
    return 0;
}
```