### PR TITLE
 Add the "codegen" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,33 @@ optional arguments:
 
 ```
 
+### codegen の詳細
+
+```
+usage: ./atcoder-tools codegen [-h] [--without-login] [--lang LANG]
+                               [--template TEMPLATE] [--save-no-session-cache]
+                               [--config CONFIG]
+                               url
+
+positional arguments:
+  url                   URL (e.g. https://atcoder.jp/contests/abc012/tasks/abc012_3)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --without-login       Download data without login
+  --lang LANG           Programming language of your template code, cpp or java or rust.
+                        [Default] cpp
+  --template TEMPLATE   File path to your template code
+                        [Default (C++)] /home/user/GitHub/atcoder-tools/atcodertools/tools/templates/default_template.cpp
+                        [Default (Java)] /home/user/GitHub/atcoder-tools/atcodertools/tools/templates/default_template.java
+                        [Default (Rust)] /home/user/GitHub/atcoder-tools/atcodertools/tools/templates/default_template.rs
+  --save-no-session-cache
+                        Save no session cache to avoid security risk
+  --config CONFIG       File path to your config file
+                        [Default (Primary)] /home/user/.atcodertools.toml
+                        [Default (Secondary)] /home/user/GitHub/atcoder-tools/atcodertools/tools/atcodertools-default.toml
+```
+
 
 ## 設定ファイルの例
 `~/.atcodertools.toml`に以下の設定を保存すると、コードスタイルや、コード生成後に実行するコマンドを指定できます。

--- a/atcoder-tools
+++ b/atcoder-tools
@@ -5,6 +5,7 @@ from atcodertools.release_management.version_check import get_latest_version, Ve
 from atcodertools.tools.envgen import main as envgen_main
 from atcodertools.tools.tester import main as tester_main
 from atcodertools.tools.submit import main as submit_main
+from atcodertools.tools.codegen import main as codegen_main
 from atcodertools.release_management.version import __version__
 from colorama import Fore, Style
 
@@ -34,12 +35,13 @@ def notify_if_latest_version_found():
 if __name__ == '__main__':
     notify_if_latest_version_found()
 
-    if len(sys.argv) < 2 or sys.argv[1] not in ("gen", "test", "submit"):
+    if len(sys.argv) < 2 or sys.argv[1] not in ("gen", "test", "submit", "codegen"):
         print("Usage:")
         print("{} gen -- to generate workspace".format(sys.argv[0]))
         print("{} test -- to test codes in your workspace".format(sys.argv[0]))
         print(
             "{} submit -- to submit a code to the contest system".format(sys.argv[0]))
+        print("{} codegen -- to generate a code".format(sys.argv[0]))
         sys.exit(-1)
 
     prog = " ".join(sys.argv[:2])
@@ -53,3 +55,6 @@ if __name__ == '__main__':
 
     if sys.argv[1] == "submit":
         exit_program(submit_main(prog, args))
+
+    if sys.argv[1] == "codegen":
+        exit_program(codegen_main(prog, args))

--- a/atcoder-tools
+++ b/atcoder-tools
@@ -57,4 +57,4 @@ if __name__ == '__main__':
         exit_program(submit_main(prog, args))
 
     if sys.argv[1] == "codegen":
-        exit_program(codegen_main(prog, args))
+        codegen_main(prog, args)

--- a/atcoder-tools
+++ b/atcoder-tools
@@ -41,7 +41,8 @@ if __name__ == '__main__':
         print("{} test -- to test codes in your workspace".format(sys.argv[0]))
         print(
             "{} submit -- to submit a code to the contest system".format(sys.argv[0]))
-        print("{} codegen -- to generate a code".format(sys.argv[0]))
+        print(
+            "{} codegen -- to generate a code for a given problem (stdout)".format(sys.argv[0]))
         sys.exit(-1)
 
     prog = " ".join(sys.argv[:2])

--- a/atcodertools/tools/codegen.py
+++ b/atcodertools/tools/codegen.py
@@ -6,6 +6,7 @@ import posixpath
 import re
 import sys
 import urllib
+from io import IOBase
 
 from colorama import Fore
 
@@ -59,7 +60,8 @@ def get_problem_from_url(problem_url: str) -> Problem:
 
 def generate_code(atcoder_client: AtCoderClient,
                   problem_url: str,
-                  config: Config):
+                  config: Config,
+                  output_file: IOBase):
     problem = get_problem_from_url(problem_url)
     template_code_path = config.code_style_config.template_file
     lang = config.code_style_config.lang
@@ -104,7 +106,7 @@ def generate_code(atcoder_client: AtCoderClient,
 
     output_splitter()
 
-    sys.stdout.write(code_generator(
+    output_file.write(code_generator(
         CodeGenArgs(
             template,
             prediction_result.format,
@@ -113,7 +115,7 @@ def generate_code(atcoder_client: AtCoderClient,
         )))
 
 
-def main(prog, args):
+def main(prog, args, output_file=sys.stdout):
     parser = argparse.ArgumentParser(
         prog=prog,
         formatter_class=argparse.RawTextHelpFormatter)
@@ -172,7 +174,8 @@ def main(prog, args):
 
     generate_code(client,
                   args.url,
-                  config)
+                  config,
+                  output_file=output_file)
 
 
 if __name__ == "__main__":

--- a/atcodertools/tools/codegen.py
+++ b/atcodertools/tools/codegen.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python3
+import argparse
+import logging
+import os
+import posixpath
+import re
+import sys
+import urllib
+
+from colorama import Fore
+
+from atcodertools.client.atcoder import AtCoderClient, Contest, LoginError
+from atcodertools.client.models.problem import Problem
+from atcodertools.client.models.problem_content import InputFormatDetectionError, SampleDetectionError
+from atcodertools.codegen.code_style_config import DEFAULT_WORKSPACE_DIR_PATH
+from atcodertools.codegen.models.code_gen_args import CodeGenArgs
+from atcodertools.common.language import ALL_LANGUAGES, CPP
+from atcodertools.config.config import Config
+from atcodertools.constprediction.constants_prediction import predict_constants
+from atcodertools.fmtprediction.models.format_prediction_result import FormatPredictionResult
+from atcodertools.fmtprediction.predict_format import MultiplePredictionResultsError, NoPredictionResultError, predict_format
+from atcodertools.tools import get_default_config_path
+from atcodertools.tools.envgen import USER_CONFIG_PATH, get_config, output_splitter
+from atcodertools.tools.utils import with_color
+
+
+class UnknownProblemURLError(Exception):
+    pass
+
+
+def get_problem_from_url(problem_url: str) -> Problem:
+    dummy_alphabet = 'Z'  # it's impossible to reconstruct the alphabet from URL
+    result = urllib.parse.urlparse(problem_url)
+
+    # old-style (e.g. http://agc012.contest.atcoder.jp/tasks/agc012_d)
+    dirname, basename = posixpath.split(os.path.normpath(result.path))
+    if result.scheme in ('', 'http', 'https') \
+            and result.netloc.count('.') == 3 \
+            and result.netloc.endswith('.contest.atcoder.jp') \
+            and result.netloc.split('.')[0] \
+            and dirname == '/tasks' \
+            and basename:
+        contest_id = result.netloc.split('.')[0]
+        problem_id = basename
+        return Problem(Contest(contest_id), dummy_alphabet, problem_id)
+
+    # new-style (e.g. https://beta.atcoder.jp/contests/abc073/tasks/abc073_a)
+    m = re.match(
+        r'^/contests/([\w\-_]+)/tasks/([\w\-_]+)$', os.path.normpath(result.path))
+    if result.scheme in ('', 'http', 'https') \
+            and result.netloc in ('atcoder.jp', 'beta.atcoder.jp') \
+            and m:
+        contest_id = m.group(1)
+        problem_id = m.group(2)
+        return Problem(Contest(contest_id), dummy_alphabet, problem_id)
+
+    raise UnknownProblemURLError
+
+
+def generate_code(atcoder_client: AtCoderClient,
+                  problem_url: str,
+                  config: Config):
+    problem = get_problem_from_url(problem_url)
+    template_code_path = config.code_style_config.template_file
+    lang = config.code_style_config.lang
+
+    def emit_error(text):
+        logging.error(with_color(text, Fore.RED))
+
+    def emit_warning(text):
+        logging.warning(text)
+
+    def emit_info(text):
+        logging.info(text)
+
+    emit_info('{} is used for template'.format(template_code_path))
+
+    # Fetch problem data from the statement
+    try:
+        content = atcoder_client.download_problem_content(problem)
+    except InputFormatDetectionError as e:
+        emit_error("Failed to download input format.")
+        raise e
+    except SampleDetectionError as e:
+        emit_error("Failed to download samples.")
+        raise e
+
+    try:
+        prediction_result = predict_format(content)
+        emit_info(
+            with_color("Format prediction succeeded", Fore.LIGHTGREEN_EX))
+    except (NoPredictionResultError, MultiplePredictionResultsError) as e:
+        prediction_result = FormatPredictionResult.empty_result()
+        if isinstance(e, NoPredictionResultError):
+            msg = "No prediction -- Failed to understand the input format"
+        else:
+            msg = "Too many prediction -- Failed to understand the input format"
+        emit_warning(with_color(msg, Fore.LIGHTRED_EX))
+
+    constants = predict_constants(content.original_html)
+    code_generator = config.code_style_config.code_generator
+    with open(template_code_path, "r") as f:
+        template = f.read()
+
+    output_splitter()
+
+    sys.stdout.write(code_generator(
+        CodeGenArgs(
+            template,
+            prediction_result.format,
+            constants,
+            config.code_style_config
+        )))
+
+
+def main(prog, args):
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.add_argument("url",
+                        help="URL (e.g. https://atcoder.jp/contests/abc012/tasks/abc012_3)")
+
+    parser.add_argument("--without-login",
+                        action="store_true",
+                        help="Download data without login")
+
+    parser.add_argument("--lang",
+                        help="Programming language of your template code, {}.\n"
+                        .format(" or ".join([lang.name for lang in ALL_LANGUAGES])) + "[Default] {}".format(CPP.name))
+
+    parser.add_argument("--template",
+                        help="File path to your template code\n{}".format(
+                            "\n".join(
+                                ["[Default ({dname})] {path}".format(
+                                    dname=lang.display_name,
+                                    path=lang.default_template_path
+                                ) for lang in ALL_LANGUAGES]
+                            ))
+                        )
+
+    parser.add_argument("--save-no-session-cache",
+                        action="store_true",
+                        help="Save no session cache to avoid security risk",
+                        default=None)
+
+    parser.add_argument("--config",
+                        help="File path to your config file\n{0}{1}".format("[Default (Primary)] {}\n".format(
+                            USER_CONFIG_PATH),
+                            "[Default (Secondary)] {}\n".format(
+                                get_default_config_path()))
+                        )
+
+    args = parser.parse_args(args)
+
+    args.workspace = DEFAULT_WORKSPACE_DIR_PATH  # dummy for get_config()
+    args.parallel = False  # dummy for get_config()
+    config = get_config(args)
+
+    client = AtCoderClient()
+    if not config.etc_config.download_without_login:
+        try:
+            client.login(
+                save_session_cache=not config.etc_config.save_no_session_cache)
+            logging.info("Login successful.")
+        except LoginError:
+            logging.error(
+                "Failed to login (maybe due to wrong username/password combination?)")
+            sys.exit(-1)
+    else:
+        logging.info("Downloading data without login.")
+
+    generate_code(client,
+                  args.url,
+                  config)
+
+
+if __name__ == "__main__":
+    main(sys.argv[0], sys.argv[1:])

--- a/tests/resources/test_codegen_command/generated_code.cpp
+++ b/tests/resources/test_codegen_command/generated_code.cpp
@@ -1,0 +1,22 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+void solve(long long N, long long M, std::vector<long long> a, std::vector<long long> b, std::vector<long long> t){
+
+}
+int main(){
+    long long N;
+    scanf("%lld",&N);
+    long long M;
+    scanf("%lld",&M);
+    std::vector<long long> a(M);
+    std::vector<long long> b(M);
+    std::vector<long long> t(M);
+    for(int i = 0 ; i < M ; i++){
+        scanf("%lld",&a[i]);
+        scanf("%lld",&b[i]);
+        scanf("%lld",&t[i]);
+    }
+    solve(N, M, std::move(a), std::move(b), std::move(t));
+    return 0;
+}

--- a/tests/resources/test_codegen_command/template_jinja.cpp
+++ b/tests/resources/test_codegen_command/template_jinja.cpp
@@ -1,0 +1,20 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+{% if mod is not none %}
+const int mod = {{ mod }};
+{% endif %}
+{% if yes_str is not none %}
+const string YES = "{{ yes_str }}";
+{% endif %}
+{% if no_str is not none %}
+const string NO = "{{ no_str }}";
+{% endif %}
+void solve({{ formal_arguments }}){
+
+}
+int main(){
+    {{input_part}}
+    solve({{ actual_arguments }});
+    return 0;
+}

--- a/tests/test_codegen_command.py
+++ b/tests/test_codegen_command.py
@@ -1,0 +1,40 @@
+import io
+import os
+import unittest
+
+from atcodertools.tools.codegen import main
+
+RESOURCE_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "./resources/test_codegen_command/")
+TEMPLATE_PATH = os.path.join(RESOURCE_DIR, "template_jinja.cpp")
+
+
+class TestCodeGenCOmmand(unittest.TestCase):
+
+    def test_generate_code(self):
+        answer_data_dir_path = os.path.join(
+            RESOURCE_DIR,
+            "test_prepare_workspace")
+
+        config_path = os.path.join(RESOURCE_DIR, "test_codegen_command.toml")
+        correct_file_path = os.path.join(RESOURCE_DIR, "generated_code.cpp")
+        f1 = io.StringIO()
+
+        main(
+            "",
+            ["https://atcoder.jp/contests/abc012/tasks/abc012_4",
+             "--template", TEMPLATE_PATH,
+             "--lang", "cpp",
+             "--without-login",
+             '--config', config_path
+             ],
+            output_file=f1
+        )
+
+        with open(correct_file_path) as f2:
+            self.assertEqual(f1.getvalue(), f2.read())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_codegen_command.py
+++ b/tests/test_codegen_command.py
@@ -2,7 +2,9 @@ import io
 import os
 import unittest
 
-from atcodertools.tools.codegen import main
+from atcodertools.client.models.contest import Contest
+from atcodertools.client.models.problem import Problem
+from atcodertools.tools.codegen import main, get_problem_from_url
 
 RESOURCE_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -34,6 +36,24 @@ class TestCodeGenCommand(unittest.TestCase):
 
         with open(answer_file_path) as f2:
             self.assertEqual(f1.getvalue(), f2.read())
+
+    def test_url_parser(self):
+        dummy_alphabet = "Z"
+        problem = Problem(Contest("utpc2014"), "Z", "utpc2014_k")
+        urls = [
+            "http://utpc2014.contest.atcoder.jp/tasks/utpc2014_k",
+            "http://beta.atcoder.jp/contests/utpc2014/tasks/utpc2014_k",
+            "http://atcoder.jp/contests/utpc2014/tasks/utpc2014_k",
+            "https://utpc2014.contest.atcoder.jp/tasks/utpc2014_k",
+            "https://beta.atcoder.jp/contests/utpc2014/tasks/utpc2014_k",
+            "https://atcoder.jp/contests/utpc2014/tasks/utpc2014_k",
+            "https://atcoder.jp/contests/utpc2014/tasks/utpc2014_k?lang=en",
+            "https://atcoder.jp/contests/utpc2014/tasks/utpc2014_k/?lang=en",
+        ]
+
+        for url in urls:
+            self.assertEqual(
+                get_problem_from_url(url).to_dict(), problem.to_dict())
 
 
 if __name__ == '__main__':

--- a/tests/test_codegen_command.py
+++ b/tests/test_codegen_command.py
@@ -10,7 +10,7 @@ RESOURCE_DIR = os.path.join(
 TEMPLATE_PATH = os.path.join(RESOURCE_DIR, "template_jinja.cpp")
 
 
-class TestCodeGenCOmmand(unittest.TestCase):
+class TestCodeGenCommand(unittest.TestCase):
 
     def test_generate_code(self):
         answer_data_dir_path = os.path.join(
@@ -18,7 +18,7 @@ class TestCodeGenCOmmand(unittest.TestCase):
             "test_prepare_workspace")
 
         config_path = os.path.join(RESOURCE_DIR, "test_codegen_command.toml")
-        correct_file_path = os.path.join(RESOURCE_DIR, "generated_code.cpp")
+        answer_file_path = os.path.join(RESOURCE_DIR, "generated_code.cpp")
         f1 = io.StringIO()
 
         main(
@@ -32,7 +32,7 @@ class TestCodeGenCOmmand(unittest.TestCase):
             output_file=f1
         )
 
-        with open(correct_file_path) as f2:
+        with open(answer_file_path) as f2:
             self.assertEqual(f1.getvalue(), f2.read())
 
 


### PR DESCRIPTION
ユーザインターフェースは以下のようになりました。
`gen` サブコマンドのものを拝借してできるだけ似せた形です。
言語の指定は、デフォルトではconfigファイルを読みに行きます。

``` console
$ ./atcoder-tools codegen -h
usage: ./atcoder-tools codegen [-h] [--without-login] [--lang LANG]
                               [--template TEMPLATE] [--save-no-session-cache]
                               [--config CONFIG]
                               url

positional arguments:
  url                   URL (e.g. https://atcoder.jp/contests/abc012/tasks/abc012_3)

optional arguments:
  -h, --help            show this help message and exit
  --without-login       Download data without login
  --lang LANG           Programming language of your template code, cpp or java or rust.
                        [Default] cpp
  --template TEMPLATE   File path to your template code
                        [Default (C++)] /home/user/GitHub/atcoder-tools/atcodertools/tools/templates/default_template.cpp
                        [Default (Java)] /home/user/GitHub/atcoder-tools/atcodertools/tools/templates/default_template.java
                        [Default (Rust)] /home/user/GitHub/atcoder-tools/atcodertools/tools/templates/default_template.rs
  --save-no-session-cache
                        Save no session cache to avoid security risk
  --config CONFIG       File path to your config file
                        [Default (Primary)] /home/user/.atcodertools.toml
                        [Default (Secondary)] /home/user/GitHub/atcoder-tools/atcodertools/tools/atcodertools-default.toml
```

-   実装の重複を防ぐために `gen` サブコマンドの実装の内部の関数を借りてきてます。コピペを嫌って直接 import してますが、これはこれで依存が後々つらいので後で refactoring が必要です。
-   https://github.com/kyuridenamida/atcoder-tools/issues/96#issuecomment-463877561 で「code generator をオプションで指定したい」という話が出ていますが、これは今のところしていません。書き終わってから気付いたことと、足すとすれば `gen` コマンドに足すのと同時に行なうべきだろうことが理由です。必要なら別のプルリクとして投げます。
-   template のオプションでの指定はできます。
-   テストがひとつしかなくてさみしいですが、下位の機能のコード自動生成部分の wrapper でしかないので、まったく不足しているということもないはずです。