### PR TITLE
Distinguish AC with stderr from WA on test command

### DIFF
--- a/atcodertools/tools/tester.py
+++ b/atcodertools/tools/tester.py
@@ -60,7 +60,7 @@ def infer_case_num(sample_filename: str):
     return int(result)
 
 
-def build_details_str(exec_res: ExecResult, input_file: str, output_file: str, skip_io_on_success: bool) -> str:
+def build_details_str(exec_res: ExecResult, input_file: str, output_file: str) -> str:
     res = ""
 
     def append(text: str, end='\n'):
@@ -70,16 +70,15 @@ def build_details_str(exec_res: ExecResult, input_file: str, output_file: str, s
     with open(output_file, "r") as f:
         expected_output = f.read()
 
-    if expected_output != exec_res.output or not skip_io_on_success:
-        append(with_color("[Input]", Fore.LIGHTMAGENTA_EX))
-        with open(input_file, "r") as f:
-            append(f.read(), end='')
+    append(with_color("[Input]", Fore.LIGHTMAGENTA_EX))
+    with open(input_file, "r") as f:
+        append(f.read(), end='')
 
-        append(with_color("[Expected]", Fore.LIGHTMAGENTA_EX))
-        append(expected_output, end='')
+    append(with_color("[Expected]", Fore.LIGHTMAGENTA_EX))
+    append(expected_output, end='')
 
-        append(with_color("[Received]", Fore.LIGHTMAGENTA_EX))
-        append(exec_res.output, end='')
+    append(with_color("[Received]", Fore.LIGHTMAGENTA_EX))
+    append(exec_res.output, end='')
 
     if exec_res.status != ExecStatus.NORMAL:
         append(with_color("Aborted ({})\n".format(
@@ -129,9 +128,9 @@ def run_for_samples(exec_file: str, sample_pair_list: List[Tuple[str, str]], tim
         ))
 
         # Output details for incorrect results or has stderr.
-        if not is_correct or exec_res.has_stderr():
+        if not is_correct or (exec_res.has_stderr() and not skip_io_on_success):
             print('{}\n'.format(build_details_str(
-                exec_res, in_sample_file, out_sample_file, skip_io_on_success)))
+                exec_res, in_sample_file, out_sample_file)))
 
         if knock_out and not is_correct:
             print('Stop testing ...')

--- a/atcodertools/tools/tester.py
+++ b/atcodertools/tools/tester.py
@@ -60,7 +60,7 @@ def infer_case_num(sample_filename: str):
     return int(result)
 
 
-def build_details_str(exec_res: ExecResult, input_file: str, output_file: str, squash_io_on_success: bool) -> str:
+def build_details_str(exec_res: ExecResult, input_file: str, output_file: str, skip_io_on_success: bool) -> str:
     res = ""
 
     def append(text: str, end='\n'):
@@ -70,7 +70,7 @@ def build_details_str(exec_res: ExecResult, input_file: str, output_file: str, s
     with open(output_file, "r") as f:
         expected_output = f.read()
 
-    if expected_output != exec_res.output or not squash_io_on_success:
+    if expected_output != exec_res.output or not skip_io_on_success:
         append(with_color("[Input]", Fore.LIGHTMAGENTA_EX))
         with open(input_file, "r") as f:
             append(f.read(), end='')
@@ -92,7 +92,7 @@ def build_details_str(exec_res: ExecResult, input_file: str, output_file: str, s
 
 
 def run_for_samples(exec_file: str, sample_pair_list: List[Tuple[str, str]], timeout_sec: int, knock_out: bool = False,
-                    squash_io_on_success: bool = False) -> TestSummary:
+                    skip_io_on_success: bool = False) -> TestSummary:
     success_count = 0
     has_error_output = False
     for in_sample_file, out_sample_file in sample_pair_list:
@@ -131,7 +131,7 @@ def run_for_samples(exec_file: str, sample_pair_list: List[Tuple[str, str]], tim
         # Output details for incorrect results or has stderr.
         if not is_correct or exec_res.has_stderr():
             print('{}\n'.format(build_details_str(
-                exec_res, in_sample_file, out_sample_file, squash_io_on_success)))
+                exec_res, in_sample_file, out_sample_file, skip_io_on_success)))
 
         if knock_out and not is_correct:
             print('Stop testing ...')
@@ -176,7 +176,7 @@ def run_single_test(exec_file, in_sample_file_list, out_sample_file_list, timeou
 
 
 def run_all_tests(exec_file, in_sample_file_list, out_sample_file_list, timeout_sec: int, knock_out: bool,
-                  squash_stderr_onsuccess: bool) -> bool:
+                  skip_stderr_on_success: bool) -> bool:
     if len(in_sample_file_list) != len(out_sample_file_list):
         logging.error("{0}{1}{2}".format(
             "The number of the sample inputs and outputs are different.\n",
@@ -189,7 +189,7 @@ def run_all_tests(exec_file, in_sample_file_list, out_sample_file_list, timeout_
         samples.append((in_sample_file, out_sample_file))
 
     test_summary = run_for_samples(
-        exec_file, samples, timeout_sec, knock_out, squash_stderr_onsuccess)
+        exec_file, samples, timeout_sec, knock_out, skip_stderr_on_success)
 
     if len(samples) == 0:
         print("No test cases")
@@ -255,7 +255,7 @@ def main(prog, args) -> bool:
                         action="store_true",
                         default=False)
 
-    parser.add_argument('--squash-inout', '-s',
+    parser.add_argument('--skip-almost-ac-feedback', '-s',
                         help='Hide inputs and expected/actual outputs if result is correct and there are error outputs'
                              ' [Default] False,',
                         action='store_true',
@@ -275,7 +275,7 @@ def main(prog, args) -> bool:
 
     if args.num is None:
         return run_all_tests(exec_file, in_sample_file_list, out_sample_file_list, args.timeout, args.knock_out,
-                             args.squash_inout)
+                             args.skip_almost_ac_feedback)
     else:
         return run_single_test(exec_file, in_sample_file_list, out_sample_file_list, args.timeout, args.num)
 

--- a/atcodertools/tools/tester.py
+++ b/atcodertools/tools/tester.py
@@ -188,7 +188,8 @@ def run_all_tests(exec_file, in_sample_file_list, out_sample_file_list, timeout_
         validate_sample_pair(in_sample_file, out_sample_file)
         samples.append((in_sample_file, out_sample_file))
 
-    test_summary = run_for_samples(exec_file, samples, timeout_sec, knock_out, squash_stderr_onsuccess)
+    test_summary = run_for_samples(
+        exec_file, samples, timeout_sec, knock_out, squash_stderr_onsuccess)
 
     if len(samples) == 0:
         print("No test cases")
@@ -201,7 +202,8 @@ def run_all_tests(exec_file, in_sample_file_list, out_sample_file_list, timeout_
         ))
         return False
     elif test_summary.has_error_output:
-        print(with_color("Passed all test case but with stderr. (Please remove stderr!)", Fore.LIGHTYELLOW_EX))
+        print(with_color(
+            "Passed all test case but with stderr. (Please remove stderr!)", Fore.LIGHTYELLOW_EX))
         return False
     else:
         print(with_color("Passed all test cases!!!", Fore.LIGHTGREEN_EX))

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -96,6 +96,18 @@ class TestTester(unittest.TestCase):
             self.assertEqual(1, run_program_mock.call_count)
             self.assertEqual(1, build_details_str_mock.call_count)
 
+    @patch('atcodertools.tools.tester.build_details_str', return_value='')
+    @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'correct', 'stderr', 0))
+    def test_run_for_samples__skip_stderr(self, run_program_mock: MagicMock, build_details_str_mock: MagicMock):
+        io_mock = mock_open(read_data='correct')
+
+        with patch('atcodertools.tools.tester.open', io_mock):
+            self.assertEqual(TestSummary(1, True), tester.run_for_samples(
+                'a.out', [('in_1.txt', 'out_1.txt')], 1, skip_io_on_success=True))
+            self.assertEqual(1, run_program_mock.call_count)
+            self.assertEqual(0, build_details_str_mock.call_count)
+
+
     def test_build_details_str(self):
         in_out = 'correct\n'
         output = 'wrong\n'
@@ -110,7 +122,7 @@ class TestTester(unittest.TestCase):
 
         with patch('atcodertools.tools.tester.open', io_mock):
             result = build_details_str(ExecResult(
-                ExecStatus.NORMAL, output, stderr), 'in.txt', 'out.txt', False)
+                ExecStatus.NORMAL, output, stderr), 'in.txt', 'out.txt')
             self.assertEqual(expected, result)
 
     def test_build_details_str__show_testcase_if_there_is_stderr(self):
@@ -126,17 +138,7 @@ class TestTester(unittest.TestCase):
 
         with patch('atcodertools.tools.tester.open', io_mock):
             result = build_details_str(ExecResult(
-                ExecStatus.NORMAL, in_out, stderr), 'in.txt', 'out.txt', False)
-            self.assertEqual(expected, result)
-
-    def test_build_details_str__hide_testcase_on_correct_answer(self):
-        io_mock = mock_open(read_data='correct\n')
-
-        with patch('atcodertools.tools.tester.open', io_mock):
-            expected = with_color(
-                '[Error]', Fore.LIGHTYELLOW_EX) + '\nstderr\n'
-            result = build_details_str(ExecResult(
-                ExecStatus.NORMAL, 'correct\n', 'stderr\n'), 'in.txt', 'out.txt', True)
+                ExecStatus.NORMAL, in_out, stderr), 'in.txt', 'out.txt')
             self.assertEqual(expected, result)
 
     def test_build_details_str__on_runtime_failure(self):
@@ -152,7 +154,7 @@ class TestTester(unittest.TestCase):
 
         with patch('atcodertools.tools.tester.open', io_mock):
             result = build_details_str(ExecResult(
-                ExecStatus.RE, in_out, stderr), 'in.txt', 'out.txt', False)
+                ExecStatus.RE, in_out, stderr), 'in.txt', 'out.txt')
             self.assertEqual(expected, result)
 
 

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -57,7 +57,7 @@ class TestTester(unittest.TestCase):
 
         with patch('atcodertools.tools.tester.open', io_mock):
             self.assertEqual(TestSummary(1, False), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
-            run_program_mock.assert_called_once()
+            self.assertEqual(1, run_program_mock.call_count)
 
     @patch('atcodertools.tools.tester.build_details_str', return_value='')
     @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'correct', 'stderr', 0))
@@ -66,8 +66,8 @@ class TestTester(unittest.TestCase):
 
         with patch('atcodertools.tools.tester.open', io_mock):
             self.assertEqual(TestSummary(1, True), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
-            run_program_mock.assert_called_once()
-            build_details_str_mock.assert_called_once()
+            self.assertEqual(1, run_program_mock.call_count)
+            self.assertEqual(1, build_details_str_mock.call_count)
 
     @patch('atcodertools.tools.tester.build_details_str', return_value='')
     @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'wrong', '', 0))
@@ -76,8 +76,8 @@ class TestTester(unittest.TestCase):
 
         with patch('atcodertools.tools.tester.open', io_mock):
             self.assertEqual(TestSummary(0, False), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
-            run_program_mock.assert_called_once()
-            build_details_str_mock.assert_called_once()
+            self.assertEqual(1, run_program_mock.call_count)
+            self.assertEqual(1, build_details_str_mock.call_count)
 
     @patch('atcodertools.tools.tester.build_details_str', return_value='')
     @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'wrong', '', 0))
@@ -88,8 +88,8 @@ class TestTester(unittest.TestCase):
         with patch('atcodertools.tools.tester.open', io_mock):
             sample_pair_list = [('in_1.txt', 'out_1.txt'), ('in_2.txt', 'out_2.txt')]
             self.assertEqual(TestSummary(0, False), tester.run_for_samples('a.out', sample_pair_list, 1, True))
-            run_program_mock.assert_called_once()
-            build_details_str_mock.assert_called_once()
+            self.assertEqual(1, run_program_mock.call_count)
+            self.assertEqual(1, build_details_str_mock.call_count)
 
     def test_build_details_str(self):
         in_out = 'correct\n'

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -101,8 +101,10 @@ class TestTester(unittest.TestCase):
         output = 'wrong\n'
         stderr = 'stderr\n'
         expected = (with_color('[Input]', Fore.LIGHTMAGENTA_EX) + '\n'
-                    + in_out + with_color('[Expected]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
-                    + with_color('[Received]', Fore.LIGHTMAGENTA_EX) + '\n' + output
+                    + in_out + with_color('[Expected]',
+                                          Fore.LIGHTMAGENTA_EX) + '\n' + in_out
+                    + with_color('[Received]',
+                                 Fore.LIGHTMAGENTA_EX) + '\n' + output
                     + with_color('[Error]', Fore.LIGHTYELLOW_EX) + '\n' + stderr)
         io_mock = mock_open(read_data=in_out)
 

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -1,9 +1,10 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, mock_open, MagicMock
 
+from atcodertools.executils.run_program import ExecResult, ExecStatus
 from atcodertools.tools import tester
-from atcodertools.tools.tester import is_executable_file
+from atcodertools.tools.tester import is_executable_file, TestSummary
 
 RESOURCE_DIR = os.path.abspath(os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -46,6 +47,46 @@ class TestTester(unittest.TestCase):
     @patch('pathlib.Path.is_file', return_value=False)
     def test_is_executable_file__directory(self, os_mock, is_file_mock):
         self.assertFalse(is_executable_file('directory'))
+
+    @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'correct', '', 0))
+    def test_run_for_samples(self, run_program_mock: MagicMock):
+        io_mock = mock_open(read_data='correct')
+
+        with patch('atcodertools.tools.tester.open', io_mock):
+            self.assertEqual(TestSummary(1, False), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
+            run_program_mock.assert_called_once()
+
+    @patch('atcodertools.tools.tester.build_details_str', return_value='')
+    @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'correct', 'stderr', 0))
+    def test_run_for_samples__with_stderr(self, run_program_mock: MagicMock, build_details_str_mock: MagicMock):
+        io_mock = mock_open(read_data='correct')
+
+        with patch('atcodertools.tools.tester.open', io_mock):
+            self.assertEqual(TestSummary(1, True), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
+            run_program_mock.assert_called_once()
+            build_details_str_mock.assert_called_once()
+
+    @patch('atcodertools.tools.tester.build_details_str', return_value='')
+    @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'wrong', '', 0))
+    def test_run_for_samples__wrong_answer(self, run_program_mock: MagicMock, build_details_str_mock: MagicMock):
+        io_mock = mock_open(read_data='correct')
+
+        with patch('atcodertools.tools.tester.open', io_mock):
+            self.assertEqual(TestSummary(0, False), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
+            run_program_mock.assert_called_once()
+            build_details_str_mock.assert_called_once()
+
+    @patch('atcodertools.tools.tester.build_details_str', return_value='')
+    @patch('atcodertools.tools.tester.run_program', return_value=ExecResult(ExecStatus.NORMAL, 'wrong', '', 0))
+    def test_run_for_samples__stop_execution_on_first_failure(self, run_program_mock: MagicMock,
+                                                              build_details_str_mock: MagicMock):
+        io_mock = mock_open(read_data='correct')
+
+        with patch('atcodertools.tools.tester.open', io_mock):
+            sample_pair_list = [('in_1.txt', 'out_1.txt'), ('in_2.txt', 'out_2.txt')]
+            self.assertEqual(TestSummary(0, False), tester.run_for_samples('a.out', sample_pair_list, 1, True))
+            run_program_mock.assert_called_once()
+            build_details_str_mock.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -95,10 +95,10 @@ class TestTester(unittest.TestCase):
         in_out = 'correct\n'
         output = 'wrong\n'
         stderr = 'stderr\n'
-        expected = with_color('[Input]', Fore.LIGHTMAGENTA_EX) + '\n'\
-                   + in_out + with_color('[Expected]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out\
-                   + with_color('[Received]', Fore.LIGHTMAGENTA_EX) + '\n' + output\
-                   + with_color('[Error]', Fore.LIGHTYELLOW_EX) + '\n' + stderr
+        expected = (with_color('[Input]', Fore.LIGHTMAGENTA_EX) + '\n'
+                   + in_out + with_color('[Expected]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
+                   + with_color('[Received]', Fore.LIGHTMAGENTA_EX) + '\n' + output
+                   + with_color('[Error]', Fore.LIGHTYELLOW_EX) + '\n' + stderr)
         io_mock = mock_open(read_data=in_out)
 
         with patch('atcodertools.tools.tester.open', io_mock):

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -107,7 +107,6 @@ class TestTester(unittest.TestCase):
             self.assertEqual(1, run_program_mock.call_count)
             self.assertEqual(0, build_details_str_mock.call_count)
 
-
     def test_build_details_str(self):
         in_out = 'correct\n'
         output = 'wrong\n'

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -56,7 +56,8 @@ class TestTester(unittest.TestCase):
         io_mock = mock_open(read_data='correct')
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            self.assertEqual(TestSummary(1, False), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
+            self.assertEqual(TestSummary(1, False), tester.run_for_samples(
+                'a.out', [('in_1.txt', 'out_1.txt')], 1))
             self.assertEqual(1, run_program_mock.call_count)
 
     @patch('atcodertools.tools.tester.build_details_str', return_value='')
@@ -65,7 +66,8 @@ class TestTester(unittest.TestCase):
         io_mock = mock_open(read_data='correct')
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            self.assertEqual(TestSummary(1, True), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
+            self.assertEqual(TestSummary(1, True), tester.run_for_samples(
+                'a.out', [('in_1.txt', 'out_1.txt')], 1))
             self.assertEqual(1, run_program_mock.call_count)
             self.assertEqual(1, build_details_str_mock.call_count)
 
@@ -75,7 +77,8 @@ class TestTester(unittest.TestCase):
         io_mock = mock_open(read_data='correct')
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            self.assertEqual(TestSummary(0, False), tester.run_for_samples('a.out', [('in_1.txt', 'out_1.txt')], 1))
+            self.assertEqual(TestSummary(0, False), tester.run_for_samples(
+                'a.out', [('in_1.txt', 'out_1.txt')], 1))
             self.assertEqual(1, run_program_mock.call_count)
             self.assertEqual(1, build_details_str_mock.call_count)
 
@@ -86,8 +89,10 @@ class TestTester(unittest.TestCase):
         io_mock = mock_open(read_data='correct')
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            sample_pair_list = [('in_1.txt', 'out_1.txt'), ('in_2.txt', 'out_2.txt')]
-            self.assertEqual(TestSummary(0, False), tester.run_for_samples('a.out', sample_pair_list, 1, True))
+            sample_pair_list = [('in_1.txt', 'out_1.txt'),
+                                ('in_2.txt', 'out_2.txt')]
+            self.assertEqual(TestSummary(0, False), tester.run_for_samples(
+                'a.out', sample_pair_list, 1, True))
             self.assertEqual(1, run_program_mock.call_count)
             self.assertEqual(1, build_details_str_mock.call_count)
 
@@ -96,47 +101,56 @@ class TestTester(unittest.TestCase):
         output = 'wrong\n'
         stderr = 'stderr\n'
         expected = (with_color('[Input]', Fore.LIGHTMAGENTA_EX) + '\n'
-                   + in_out + with_color('[Expected]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
-                   + with_color('[Received]', Fore.LIGHTMAGENTA_EX) + '\n' + output
-                   + with_color('[Error]', Fore.LIGHTYELLOW_EX) + '\n' + stderr)
+                    + in_out + with_color('[Expected]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
+                    + with_color('[Received]', Fore.LIGHTMAGENTA_EX) + '\n' + output
+                    + with_color('[Error]', Fore.LIGHTYELLOW_EX) + '\n' + stderr)
         io_mock = mock_open(read_data=in_out)
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            result = build_details_str(ExecResult(ExecStatus.NORMAL, output, stderr), 'in.txt', 'out.txt', False)
+            result = build_details_str(ExecResult(
+                ExecStatus.NORMAL, output, stderr), 'in.txt', 'out.txt', False)
             self.assertEqual(expected, result)
 
     def test_build_details_str__show_testcase_if_there_is_stderr(self):
         in_out = 'correct\n'
         stderr = 'stderr\n'
         expected = (with_color('[Input]', Fore.LIGHTMAGENTA_EX) + '\n'
-                    + in_out + with_color('[Expected]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
-                    + with_color('[Received]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
+                    + in_out + with_color('[Expected]',
+                                          Fore.LIGHTMAGENTA_EX) + '\n' + in_out
+                    + with_color('[Received]',
+                                 Fore.LIGHTMAGENTA_EX) + '\n' + in_out
                     + with_color('[Error]', Fore.LIGHTYELLOW_EX) + '\n' + stderr)
         io_mock = mock_open(read_data=in_out)
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            result = build_details_str(ExecResult(ExecStatus.NORMAL, in_out, 'stderr\n'), 'in.txt', 'out.txt', False)
+            result = build_details_str(ExecResult(
+                ExecStatus.NORMAL, in_out, stderr), 'in.txt', 'out.txt', False)
             self.assertEqual(expected, result)
 
     def test_build_details_str__hide_testcase_on_correct_answer(self):
         io_mock = mock_open(read_data='correct\n')
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            expected = with_color('[Error]', Fore.LIGHTYELLOW_EX) + '\nstderr\n'
-            result = build_details_str(ExecResult(ExecStatus.NORMAL, 'correct\n', 'stderr\n'), 'in.txt', 'out.txt', True)
+            expected = with_color(
+                '[Error]', Fore.LIGHTYELLOW_EX) + '\nstderr\n'
+            result = build_details_str(ExecResult(
+                ExecStatus.NORMAL, 'correct\n', 'stderr\n'), 'in.txt', 'out.txt', True)
             self.assertEqual(expected, result)
 
     def test_build_details_str__on_runtime_failure(self):
         in_out = 'correct\n'
         stderr = ''
         expected = (with_color('[Input]', Fore.LIGHTMAGENTA_EX) + '\n'
-                    + in_out + with_color('[Expected]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
-                    + with_color('[Received]', Fore.LIGHTMAGENTA_EX) + '\n' + in_out
+                    + in_out + with_color('[Expected]',
+                                          Fore.LIGHTMAGENTA_EX) + '\n' + in_out
+                    + with_color('[Received]',
+                                 Fore.LIGHTMAGENTA_EX) + '\n' + in_out
                     + with_color('Aborted ({})\n'.format(ExecStatus.RE.name), Fore.LIGHTYELLOW_EX) + '\n')
         io_mock = mock_open(read_data=in_out)
 
         with patch('atcodertools.tools.tester.open', io_mock):
-            result = build_details_str(ExecResult(ExecStatus.RE, in_out, stderr), 'in.txt', 'out.txt', False)
+            result = build_details_str(ExecResult(
+                ExecStatus.RE, in_out, stderr), 'in.txt', 'out.txt', False)
             self.assertEqual(expected, result)
 
 


### PR DESCRIPTION
このプルリクエストでは次のことを行っています

- `atcoder-tools test`で、出力結果が正しく、標準エラー出力があったとき、テストケースをパスしたものとしてカウントする。ただし、テストケースをすべてパスしたが、標準エラー出力があったテストケースが一つでも存在したとき、テストに失敗したものとして取り扱う。（`Passed all test case but with stderr.(Please remove stderr!)`を出力し、`False`を返す）
- `atcoder-tools test -s` または`atcoder-tools --squash-inout`で、出力結果が正しく、標準エラー出力があったとき、テストケースの出力と標準出力の表示を省略する。（大量の出力によって、失敗したテストケースが探しにくくなることを防ぐため。）