### PR TITLE
root logger を使うのを止める

### DIFF
--- a/atcodertools/client/atcoder.py
+++ b/atcodertools/client/atcoder.py
@@ -1,5 +1,4 @@
 import getpass
-import logging
 import os
 import re
 import warnings
@@ -11,6 +10,7 @@ from bs4 import BeautifulSoup
 
 from atcodertools.client.models.submission import Submission
 from atcodertools.common.language import Language
+from atcodertools.common.logging import logger
 from atcodertools.fileutils.artifacts_cache import get_cache_file_path
 from atcodertools.client.models.contest import Contest
 from atcodertools.client.models.problem import Problem
@@ -28,7 +28,7 @@ def save_cookie(session: requests.Session, cookie_path: Optional[str] = None):
     cookie_path = cookie_path or default_cookie_path
     os.makedirs(os.path.dirname(cookie_path), exist_ok=True)
     session.cookies.save()
-    logging.info("Saved session into {}".format(os.path.abspath(cookie_path)))
+    logger.info("Saved session into {}".format(os.path.abspath(cookie_path)))
     os.chmod(cookie_path, 0o600)
 
 
@@ -37,7 +37,7 @@ def load_cookie_to(session: requests.Session, cookie_path: Optional[str] = None)
     session.cookies = LWPCookieJar(cookie_path)
     if os.path.exists(cookie_path):
         session.cookies.load()
-        logging.info(
+        logger.info(
             "Loaded session from {}".format(os.path.abspath(cookie_path)))
         return True
     return False
@@ -80,9 +80,9 @@ class AtCoderClient(metaclass=Singleton):
         if use_local_session_cache:
             load_cookie_to(self._session)
             if self.check_logging_in():
-                logging.info(
+                logger.info(
                     "Successfully Logged in using the previous session cache.")
-                logging.info(
+                logger.info(
                     "If you'd like to invalidate the cache, delete {}.".format(default_cookie_path))
 
                 return

--- a/atcodertools/common/logging.py
+++ b/atcodertools/common/logging.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)

--- a/atcodertools/constprediction/constants_prediction.py
+++ b/atcodertools/constprediction/constants_prediction.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from typing import Tuple, Optional
 
@@ -6,6 +5,7 @@ from bs4 import BeautifulSoup
 
 from atcodertools.constprediction.models.problem_constant_set import ProblemConstantSet
 from atcodertools.client.models.problem_content import ProblemContent, InputFormatDetectionError, SampleDetectionError
+from atcodertools.common.logging import logger
 
 
 class YesNoPredictionFailedError(Exception):
@@ -92,8 +92,8 @@ def predict_constants(html: str) -> ProblemConstantSet:
     try:
         mod = predict_modulo(html)
     except MultipleModCandidatesError as e:
-        logging.warning("Modulo prediction failed -- "
-                        "two or more candidates {} are detected as modulo values".format(e.cands))
+        logger.warning("Modulo prediction failed -- "
+                       "two or more candidates {} are detected as modulo values".format(e.cands))
         mod = None
 
     return ProblemConstantSet(mod=mod, yes_str=yes_str, no_str=no_str)

--- a/atcodertools/tools/codegen.py
+++ b/atcodertools/tools/codegen.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import argparse
-import logging
 import os
 import posixpath
 import re
@@ -16,6 +15,7 @@ from atcodertools.client.models.problem_content import InputFormatDetectionError
 from atcodertools.codegen.code_style_config import DEFAULT_WORKSPACE_DIR_PATH
 from atcodertools.codegen.models.code_gen_args import CodeGenArgs
 from atcodertools.common.language import ALL_LANGUAGES, CPP
+from atcodertools.common.logging import logger
 from atcodertools.config.config import Config
 from atcodertools.constprediction.constants_prediction import predict_constants
 from atcodertools.fmtprediction.models.format_prediction_result import FormatPredictionResult
@@ -67,13 +67,13 @@ def generate_code(atcoder_client: AtCoderClient,
     lang = config.code_style_config.lang
 
     def emit_error(text):
-        logging.error(with_color(text, Fore.RED))
+        logger.error(with_color(text, Fore.RED))
 
     def emit_warning(text):
-        logging.warning(text)
+        logger.warning(text)
 
     def emit_info(text):
-        logging.info(text)
+        logger.info(text)
 
     emit_info('{} is used for template'.format(template_code_path))
 
@@ -164,13 +164,13 @@ def main(prog, args, output_file=sys.stdout):
         try:
             client.login(
                 save_session_cache=not config.etc_config.save_no_session_cache)
-            logging.info("Login successful.")
+            logger.info("Login successful.")
         except LoginError:
-            logging.error(
+            logger.error(
                 "Failed to login (maybe due to wrong username/password combination?)")
             sys.exit(-1)
     else:
-        logging.info("Downloading data without login.")
+        logger.info("Downloading data without login.")
 
     generate_code(client,
                   args.url,

--- a/atcodertools/tools/envgen.py
+++ b/atcodertools/tools/envgen.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import argparse
-import logging
 import os
 import shutil
 import sys
@@ -18,6 +17,7 @@ from atcodertools.client.models.problem_content import InputFormatDetectionError
 from atcodertools.codegen.code_style_config import DEFAULT_WORKSPACE_DIR_PATH
 from atcodertools.codegen.models.code_gen_args import CodeGenArgs
 from atcodertools.common.language import ALL_LANGUAGES, CPP
+from atcodertools.common.logging import logger
 from atcodertools.config.config import Config
 from atcodertools.constprediction.constants_prediction import predict_constants
 from atcodertools.fileutils.create_contest_file import create_examples, \
@@ -28,9 +28,6 @@ from atcodertools.fmtprediction.predict_format import NoPredictionResultError, \
 from atcodertools.tools import get_default_config_path
 from atcodertools.tools.models.metadata import Metadata
 from atcodertools.tools.utils import with_color
-
-fmt = "%(asctime)s %(levelname)s: %(message)s"
-logging.basicConfig(level=logging.INFO, format=fmt)
 
 
 class BannedFileDetectedError(Exception):
@@ -60,13 +57,13 @@ def prepare_procedure(atcoder_client: AtCoderClient,
         pid)
 
     def emit_error(text):
-        logging.error(with_color("Problem {}: {}".format(pid, text), Fore.RED))
+        logger.error(with_color("Problem {}: {}".format(pid, text), Fore.RED))
 
     def emit_warning(text):
-        logging.warning("Problem {}: {}".format(pid, text))
+        logger.warning("Problem {}: {}".format(pid, text))
 
     def emit_info(text):
-        logging.info("Problem {}: {}".format(pid, text))
+        logger.info("Problem {}: {}".format(pid, text))
 
     emit_info('{} is used for template'.format(template_code_path))
 
@@ -169,7 +166,7 @@ def prepare_contest(atcoder_client: AtCoderClient,
         if problem_list:
             break
         sleep(retry_duration)
-        logging.warning(
+        logger.warning(
             "Failed to fetch. Will retry in {} seconds".format(retry_duration))
 
     tasks = [(atcoder_client,
@@ -194,8 +191,8 @@ def prepare_contest(atcoder_client: AtCoderClient,
     if config.postprocess_config.exec_cmd_on_contest_dir is not None:
         contest_dir_path = os.path.join(
             config.code_style_config.workspace_dir, contest_id)
-        logging.info(_message_on_execution(contest_dir_path,
-                                           config.postprocess_config.exec_cmd_on_contest_dir))
+        logger.info(_message_on_execution(contest_dir_path,
+                                          config.postprocess_config.exec_cmd_on_contest_dir))
         config.postprocess_config.execute_on_contest_dir(
             contest_dir_path)
 
@@ -206,7 +203,7 @@ USER_CONFIG_PATH = os.path.join(
 
 def get_config(args: argparse.Namespace) -> Config:
     def _load(path: str) -> Config:
-        logging.info("Going to load {} as config".format(path))
+        logger.info("Going to load {} as config".format(path))
         with open(path, 'r') as f:
             return Config.load(f, args)
 
@@ -277,9 +274,9 @@ def main(prog, args):
     args = parser.parse_args(args)
 
     if args.replacement is not None:
-        logging.error(with_color("Sorry! --replacement argument no longer exists"
-                                 " and you can only use --template."
-                                 " See the official document for details.", Fore.LIGHTRED_EX))
+        logger.error(with_color("Sorry! --replacement argument no longer exists"
+                                " and you can only use --template."
+                                " See the official document for details.", Fore.LIGHTRED_EX))
         raise DeletedFunctionalityError
 
     config = get_config(args)
@@ -296,13 +293,13 @@ def main(prog, args):
         try:
             client.login(
                 save_session_cache=not config.etc_config.save_no_session_cache)
-            logging.info("Login successful.")
+            logger.info("Login successful.")
         except LoginError:
-            logging.error(
+            logger.error(
                 "Failed to login (maybe due to wrong username/password combination?)")
             sys.exit(-1)
     else:
-        logging.info("Downloading data without login.")
+        logger.info("Downloading data without login.")
 
     prepare_contest(client,
                     args.contest_id,

--- a/atcodertools/tools/submit.py
+++ b/atcodertools/tools/submit.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import argparse
-import logging
 import sys
 import os
 
@@ -9,6 +8,7 @@ from atcodertools.tools.utils import with_color
 
 from atcodertools.client.atcoder import AtCoderClient, LoginError
 from atcodertools.tools import tester
+from atcodertools.common.logging import logger
 
 from atcodertools.tools.models.metadata import Metadata
 
@@ -58,7 +58,7 @@ def main(prog, args, credential_supplier=None, use_local_session_cache=True) -> 
     try:
         metadata = Metadata.load_from(metadata_file)
     except IOError:
-        logging.error(
+        logger.error(
             "{0} is not found! You need {0} to use this submission functionality.".format(metadata_file))
         return False
 
@@ -69,7 +69,7 @@ def main(prog, args, credential_supplier=None, use_local_session_cache=True) -> 
                      use_local_session_cache=use_local_session_cache,
                      )
     except LoginError:
-        logging.error("Login failed. Try again.")
+        logger.error("Login failed. Try again.")
         return False
 
     tester_args = []
@@ -85,19 +85,19 @@ def main(prog, args, credential_supplier=None, use_local_session_cache=True) -> 
         if not args.unlock_safety:
             for submission in submissions:
                 if submission.problem_id == metadata.problem.problem_id:
-                    logging.error(with_color("Cancel submitting because you already sent some code to the problem. Please "
-                                             "specify -u to send the code. {}".format(
-                                                 metadata.problem.contest.get_submissions_url(submission)), Fore.LIGHTRED_EX))
+                    logger.error(with_color("Cancel submitting because you already sent some code to the problem. Please "
+                                            "specify -u to send the code. {}".format(
+                                                metadata.problem.contest.get_submissions_url(submission)), Fore.LIGHTRED_EX))
                     return False
 
         code_path = args.code or os.path.join(args.dir, metadata.code_filename)
         with open(code_path, 'r') as f:
             source = f.read()
-        logging.info(
+        logger.info(
             "Submitting {} as {}".format(code_path, metadata.lang.name))
         submission = client.submit_source_code(
             metadata.problem.contest, metadata.problem, metadata.lang, source)
-        logging.info("{} {}".format(
+        logger.info("{} {}".format(
             with_color("Done!", Fore.LIGHTGREEN_EX),
             metadata.problem.contest.get_submissions_url(submission)))
 

--- a/atcodertools/tools/tester.py
+++ b/atcodertools/tools/tester.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 import argparse
 import glob
-import logging
 import os
 import sys
 from pathlib import Path
@@ -9,6 +8,7 @@ from typing import List, Tuple
 
 from colorama import Fore
 
+from atcodertools.common.logging import logger
 from atcodertools.executils.run_program import ExecResult, ExecStatus, run_program
 from atcodertools.tools.models.metadata import Metadata
 from atcodertools.tools.utils import with_color
@@ -45,7 +45,7 @@ def infer_exec_file(filenames):
 
     exec_file = exec_files[0]
     if len(exec_files) >= 2:
-        logging.warning("{0}  {1}".format(
+        logger.warning("{0}  {1}".format(
             "There're multiple executable files. '{exec_file}' is selected.".format(
                 exec_file=exec_file),
             "The candidates were {exec_files}.".format(exec_files=exec_files)))
@@ -140,7 +140,7 @@ def run_for_samples(exec_file: str, sample_pair_list: List[Tuple[str, str]], tim
 
 def validate_sample_pair(in_sample_file, out_sample_file):
     if infer_case_num(in_sample_file) != infer_case_num(out_sample_file):
-        logging.error(
+        logger.error(
             'The file combination of {} and {} is wrong.'.format(
                 in_sample_file,
                 out_sample_file
@@ -177,7 +177,7 @@ def run_single_test(exec_file, in_sample_file_list, out_sample_file_list, timeou
 def run_all_tests(exec_file, in_sample_file_list, out_sample_file_list, timeout_sec: int, knock_out: bool,
                   skip_stderr_on_success: bool) -> bool:
     if len(in_sample_file_list) != len(out_sample_file_list):
-        logging.error("{0}{1}{2}".format(
+        logger.error("{0}{1}{2}".format(
             "The number of the sample inputs and outputs are different.\n",
             "# of sample inputs: {}\n".format(len(in_sample_file_list)),
             "# of sample outputs: {}\n".format(len(out_sample_file_list))))
@@ -218,7 +218,7 @@ def get_sample_patterns(metadata_file: str) -> Tuple[str, str]:
         metadata = Metadata.load_from(metadata_file)
         return metadata.sample_in_pattern, metadata.sample_out_pattern
     except IOError:
-        logging.warning("{} is not found. Assume the example file name patterns are {} and {}".format(
+        logger.warning("{} is not found. Assume the example file name patterns are {} and {}".format(
             metadata_file,
             DEFAULT_IN_EXAMPLE_PATTERN,
             DEFAULT_OUT_EXAMPLE_PATTERN)

--- a/tests/test_constpred.py
+++ b/tests/test_constpred.py
@@ -1,7 +1,7 @@
-import logging
 import os
 import tempfile
 import unittest
+from logging import getLogger, DEBUG
 
 from atcodertools.constprediction.constants_prediction import predict_constants, predict_modulo, \
     MultipleModCandidatesError, predict_yes_no, YesNoPredictionFailedError
@@ -11,8 +11,9 @@ ANSWER_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     './resources/test_constpred/answer.txt')
 
-fmt = "%(asctime)s %(levelname)s: %(message)s"
-logging.basicConfig(level=logging.DEBUG, format=fmt)
+logger = getLogger(__name__)
+logger.setLevel(DEBUG)
+logger.format("%(asctime)s %(levelname)s: %(message)s")
 
 
 def _to_str(x):
@@ -39,7 +40,7 @@ class TestConstantsPrediction(unittest.TestCase):
         agc_html_paths = [path for path in sorted(
             os.listdir(self.test_dir)) if "agc" in path]
         for html_path, answer_line in zip(agc_html_paths, answers):
-            logging.debug("Testing {}".format(html_path))
+            logger.debug("Testing {}".format(html_path))
             constants = predict_constants(self._load(html_path))
             output_line = "{:40} [mod]{:10} [yes]{:10} [no]{:10}".format(html_path.split(".")[0],
                                                                          _to_str(

--- a/tests/test_constpred.py
+++ b/tests/test_constpred.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import unittest
-from logging import getLogger, DEBUG
+from logging import getLogger, DEBUG, Formatter, StreamHandler
 
 from atcodertools.constprediction.constants_prediction import predict_constants, predict_modulo, \
     MultipleModCandidatesError, predict_yes_no, YesNoPredictionFailedError
@@ -13,7 +13,10 @@ ANSWER_FILE = os.path.join(
 
 logger = getLogger(__name__)
 logger.setLevel(DEBUG)
-logger.format("%(asctime)s %(levelname)s: %(message)s")
+handler = StreamHandler()
+formatter = Formatter("%(asctime)s %(levelname)s: %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 
 def _to_str(x):

--- a/tests/test_envgen.py
+++ b/tests/test_envgen.py
@@ -1,15 +1,17 @@
-import logging
 import os
 import shutil
 import tempfile
 import unittest
 from os.path import relpath
+from logging import getLogger
 
 from atcodertools.client.atcoder import AtCoderClient
 from atcodertools.codegen.code_style_config import CodeStyleConfig
 from atcodertools.config.config import Config
 from atcodertools.config.etc_config import EtcConfig
 from atcodertools.tools.envgen import prepare_contest, main
+
+logger = getLogger(__name__)
 
 RESOURCE_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -33,7 +35,7 @@ class TestEnvGen(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
-        logging.info(self.temp_dir)
+        logger.info(self.temp_dir)
 
     def test_prepare_workspace(self):
         answer_data_dir_path = os.path.join(

--- a/tests/test_fmtprediction.py
+++ b/tests/test_fmtprediction.py
@@ -1,7 +1,7 @@
-import logging
 import tempfile
 import unittest
 import os
+from logging import getLogger, DEBUG
 
 from tests.utils.gzip_controller import make_tst_data_controller
 from tests.utils.fmtprediction_test_runner import FormatPredictionTestRunner
@@ -10,8 +10,9 @@ ANSWER_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     './resources/test_fmtprediction/answer.txt')
 
-fmt = "%(asctime)s %(levelname)s: %(message)s"
-logging.basicConfig(level=logging.DEBUG, format=fmt)
+logger = getLoger(__name__)
+logger.setLevel(DEBUG)
+logger.setFormatter("%(asctime)s %(levelname)s: %(message)s")
 
 
 class TestFormatPrediction(unittest.TestCase):
@@ -48,11 +49,11 @@ class TestFormatPrediction(unittest.TestCase):
                 # file.
                 case_name = ans.split()[0]
                 content = runner.load_problem_content(case_name)
-                logging.debug("=== {} ===".format(case_name))
-                logging.debug(
+                logger.debug("=== {} ===".format(case_name))
+                logger.debug(
                     "Input Format:\n{}".format(content.input_format_text))
                 for idx, s in enumerate(content.samples):
-                    logging.debug(
+                    logger.debug(
                         "Sample Input {num}:\n{inp}".format(inp=s.get_input(), num=idx + 1))
                 self.assertEqual(ans, out)
 

--- a/tests/test_fmtprediction.py
+++ b/tests/test_fmtprediction.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 import os
-from logging import getLogger, DEBUG
+from logging import getLogger, Formatter, StreamHandler, DEBUG
 
 from tests.utils.gzip_controller import make_tst_data_controller
 from tests.utils.fmtprediction_test_runner import FormatPredictionTestRunner
@@ -10,9 +10,12 @@ ANSWER_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     './resources/test_fmtprediction/answer.txt')
 
-logger = getLoger(__name__)
+logger = getLogger(__name__)
 logger.setLevel(DEBUG)
-logger.setFormatter("%(asctime)s %(levelname)s: %(message)s")
+handler = StreamHandler()
+formatter = Formatter("%(asctime)s %(levelname)s: %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 
 class TestFormatPrediction(unittest.TestCase):


### PR DESCRIPTION
Python 標準の `logging` module の使い方がきれいでないので修正します。
#134 のために必要なのですが、独立性が高いので別のプルリクとして投げました。

---

`logging` は複数のモジュールから使うことが想定されて設計されています。
log を送信するときに呼ぶメソッドを持つ class `Logger` はそのインスタンス間に木構造を持ち、ある頂点の `Logger` の設定の変更はその子孫すべてに影響します (https://docs.python.org/ja/3/howto/logging.html#logging-flow )。
なので根の `Logger` を利用するのは適切ではありません。かわりに、根からひとつ頂点を (正確にはひとつの path を) 生やしてその `Logger` を利用するようにします。