### PR TITLE
.travis.yml に書かれている flake8 が実は動いてなかったので有効にする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - pip install codecov nose
 
 script:
-  - flake8 --ignore=E501, W605
+  - flake8 --ignore=E501,W605 atcodertools tests
   - autopep8 -r . --exclude 'default_template.py,test_codegen' --diff | tee check_autopep8
   - test ! -s check_autopep8
   - atcoder-tools gen arc050 --without-login

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - pip install codecov nose
 
 script:
-  - flake8 --ignore=E501,W605 atcodertools tests
+  - flake8 --ignore=E501,W503,W605 --exclude=atcodertools/tools/templates/,tests/resources/test_codegen/ atcodertools tests
   - autopep8 -r . --exclude 'default_template.py,test_codegen' --diff | tee check_autopep8
   - test ! -s check_autopep8
   - atcoder-tools gen arc050 --without-login

--- a/atcodertools/tools/codegen.py
+++ b/atcodertools/tools/codegen.py
@@ -67,7 +67,6 @@ def generate_code(atcoder_client: AtCoderClient,
                   output_file: IOBase):
     problem = get_problem_from_url(problem_url)
     template_code_path = config.code_style_config.template_file
-    lang = config.code_style_config.lang
 
     def emit_error(text):
         logger.error(with_color(text, Fore.RED))

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -19,7 +19,6 @@ from atcodertools.codegen.code_style_config import CodeStyleConfig
 from atcodertools.codegen.models.code_gen_args import CodeGenArgs
 from atcodertools.codegen.template_engine import render
 from atcodertools.constprediction.models.problem_constant_set import ProblemConstantSet
-from atcodertools.tools.templates import get_default_template_path
 from tests.utils.fmtprediction_test_runner import FormatPredictionTestRunner, Response
 from tests.utils.gzip_controller import make_tst_data_controller
 

--- a/tests/test_codegen_command.py
+++ b/tests/test_codegen_command.py
@@ -15,10 +15,6 @@ TEMPLATE_PATH = os.path.join(RESOURCE_DIR, "template_jinja.cpp")
 class TestCodeGenCommand(unittest.TestCase):
 
     def test_generate_code(self):
-        answer_data_dir_path = os.path.join(
-            RESOURCE_DIR,
-            "test_prepare_workspace")
-
         config_path = os.path.join(RESOURCE_DIR, "test_codegen_command.toml")
         answer_file_path = os.path.join(RESOURCE_DIR, "generated_code.cpp")
         f1 = io.StringIO()
@@ -38,7 +34,6 @@ class TestCodeGenCommand(unittest.TestCase):
             self.assertEqual(f1.getvalue(), f2.read())
 
     def test_url_parser(self):
-        dummy_alphabet = "Z"
         problem = Problem(Contest("utpc2014"), "Z", "utpc2014_k")
         urls = [
             "http://utpc2014.contest.atcoder.jp/tasks/utpc2014_k",


### PR DESCRIPTION
`flake8 --ignore=E501, W605` は `W605` という空の module に対して検査をかけてしまうため、常に成功します。これはまずいので修正します。

その他の注意:

-   ディレクトリの指定があるのは、省略すると `./webapp/node_modules/node-gyp/gyp/tools/pretty_vcproj.py` などもひっかかるためです
-   `--exclude` は指定しないと ` atcodertools/tools/templates/default_template.py` や `tests/resources/test_codegen/template_jinja.py` などまでひっかかってしまいます
-   `W503` は `line break before binary operator` であり、 formatter との衝突を回避するため `--ignore` します
-   flake8 に違反するコードがいくつかあったのでついでに修正しました