### PR TITLE
include {{contest_id}} and {{problem_id}} into workspace_dir

### DIFF
--- a/atcodertools/codegen/code_style_config.py
+++ b/atcodertools/codegen/code_style_config.py
@@ -14,6 +14,7 @@ class CodeStyleConfigInitError(Exception):
 
 
 DEFAULT_WORKSPACE_DIR_PATH = os.path.join(expanduser("~"), "atcoder-workspace")
+DEFAULT_CONTEST_DIR_PATH = "{{contest_id}}"
 
 
 class CodeStyleConfig:
@@ -24,6 +25,7 @@ class CodeStyleConfig:
                  code_generator_file: Optional[str] = None,
                  template_file: Optional[str] = None,
                  workspace_dir: Optional[str] = None,
+                 contest_dir: Optional[str] = None,
                  lang: str = "cpp",
                  ):
         from atcodertools.common.language import Language, LanguageNotFoundError, ALL_LANGUAGE_NAMES
@@ -79,6 +81,8 @@ class CodeStyleConfig:
             template_file or lang.default_template_path)
         self.workspace_dir = normalize_path(
             workspace_dir or DEFAULT_WORKSPACE_DIR_PATH)
+        self.contest_dir = normalize_path(
+            contest_dir or DEFAULT_CONTEST_DIR_PATH)
         self.lang = lang
 
     def indent(self, depth):


### PR DESCRIPTION
~現状、ファイルの生成先は `workspace_dir/contest_id/problem_id/` となっていますが、`contest_id` の部分を固定にしたかったので `workspace_dir` に `{{contest_id}}` と `{{problem_id}}` までの部分を含めて、変更できるようにしてみました。
 `workspace_dir` の仕様が変わってしまうところがいまいちかなと思いますが。~