### PR TITLE
submit時にexpanderなどのコマンドを実行できるように変更

### DIFF
--- a/atcodertools/config/config.py
+++ b/atcodertools/config/config.py
@@ -6,7 +6,7 @@ import toml
 from atcodertools.codegen.code_style_config import CodeStyleConfig
 from atcodertools.config.etc_config import EtcConfig
 from atcodertools.config.postprocess_config import PostprocessConfig
-
+from atcodertools.config.submit_config import SubmitConfig
 
 def _update_config_dict(target_dic: Dict[str, Any], update_dic: Dict[str, Any]):
     return {
@@ -20,7 +20,8 @@ class Config:
     def __init__(self,
                  code_style_config: CodeStyleConfig = CodeStyleConfig(),
                  postprocess_config: PostprocessConfig = PostprocessConfig(),
-                 etc_config: EtcConfig = EtcConfig()
+                 etc_config: EtcConfig = EtcConfig(),
+                 submit_config: SubmitConfig = SubmitConfig()
                  ):
         self.code_style_config = code_style_config
         self.postprocess_config = postprocess_config
@@ -38,6 +39,7 @@ class Config:
         code_style_config_dic = config_dic.get('codestyle', {})
         postprocess_config_dic = config_dic.get('postprocess', {})
         etc_config_dic = config_dic.get('etc', {})
+        submit_config_dic = config_dic.get(_SUBMIT_CONFIG_KEY, {})
 
         if args:
             code_style_config_dic = _update_config_dict(code_style_config_dic,
@@ -54,5 +56,6 @@ class Config:
         return Config(
             code_style_config=CodeStyleConfig(**code_style_config_dic),
             postprocess_config=PostprocessConfig(**postprocess_config_dic),
-            etc_config=EtcConfig(**etc_config_dic)
+            etc_config=EtcConfig(**etc_config_dic),
+            submit_config=SubmitConfig(**submit_config_dic),
         )

--- a/atcodertools/config/submit_config.py
+++ b/atcodertools/config/submit_config.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+
+class SubmitConfig:
+
+    def __init__(self,
+                 run_exec_before_submit: bool = False,
+                 exec_before_submit: Optional[str] = None,
+                 submit_filename: Optional[str] = None
+                 ):
+        self.run_exec_before_submit = run_exec_before_submit
+        self.exec_before_submit = exec_before_submit
+        self.submit_filename = submit_filename


### PR DESCRIPTION
昨今のACL公開に伴い、主にC++以外のジャッジサーバでACLが呼べない言語でACLを用いた際、expanderにかけた結果をsubmitできるような機能を追加しました。

.atcodertools.tomlに以下を記述(下記は~/path/toにACLを置いた場合です。適宜書き換えてください)すると、submit時にexpanderが走ってexpanderの出力結果を送信してくれるはずです。expander.pyは言語ごとに修正してください。(下記はnim用です)

[submit]
run_exec_before_submit=true
exec_before_submit='python3 ~/path/to/expander.py main.nim --lib ~/path/to/'
submit_filename='./combined.nim'