### PR TITLE
Fix: Remove tests/utils from package generated by setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='tyotyo3@gmail.com',
     long_description_content_type="text/markdown",
     long_description=readme,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=_requires_from_file('requirements.txt'),
     license="MIT",
     entry_points={


### PR DESCRIPTION
`setup.py` でパッケージを生成する際に `tests` の除外設定が不完全で `tests/utils` が含まれています。

```
% zipinfo -1 atcoder_tools-1.1.7.1-py3-none-any.whl
atcodertools/__init__.py
atcodertools/atcoder_tools.py
atcodertools/client/__init__.py
...
tests/utils/__init__.py
tests/utils/fmtprediction_test_runner.py
tests/utils/gzip_controller.py
...
```

修正のため `setup.py` にあるパッケージ作成部分の `exclude` を変更します。