### PR TITLE
Support native Windows

### DIFF
--- a/atcodertools/executils/run_command.py
+++ b/atcodertools/executils/run_command.py
@@ -1,4 +1,5 @@
 import subprocess
+import locale
 
 
 def run_command(exec_cmd: str, current_working_dir: str) -> str:
@@ -7,4 +8,4 @@ def run_command(exec_cmd: str, current_working_dir: str) -> str:
                           stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT,
                           cwd=current_working_dir)
-    return proc.stdout.decode("utf8")
+    return proc.stdout.decode(locale.getpreferredencoding())

--- a/atcodertools/tools/submit.py
+++ b/atcodertools/tools/submit.py
@@ -110,8 +110,13 @@ def main(prog, args, credential_supplier=None, use_local_session_cache=True) -> 
                     return False
 
         code_path = args.code or os.path.join(args.dir, metadata.code_filename)
-        with open(code_path, 'r') as f:
-            source = f.read()
+        for encoding in ['utf8', 'utf-8_sig', 'cp932']:
+            try:
+                with open(code_path, 'r', encoding=encoding) as f:
+                    source = f.read()
+                break
+            except UnicodeDecodeError:
+                logger.warning("code wasn't recognized as {}".format(encoding))
         logger.info(
             "Submitting {} as {}".format(code_path, metadata.lang.name))
         submission = client.submit_source_code(


### PR DESCRIPTION
## Why is this change needed?

Some commands will fail on Japanese Windows that uses a special character set (CP-932).
~(this patch might not work on WSL2)~

## What did you implement?

Add CP-932 support for text operations.
e.g., `run_command("echo", ".")` returns "ECHOは ON です" on Windows.

## What behavior do you expect?

Able to run and submit code on Windows.
