### PR TITLE
Improvement in universal_generator/cpp.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ str = '""'
 # 引数
 [arg]
 int = "long long {name}"
-float = "double {name}"
+float = "long double {name}"
 str = "std::string {name}"
 seq = "std::vector<{type}> {name}"
 2d_seq = "std::vector<std::vector<{type}>> {name}"
@@ -337,7 +337,7 @@ seq = "{name}[{index}]"
 int = "long long {name};"
 float = "long double {name};"
 str = "std::string {name};"
-seq = "std::std::vector<{type}> {name};"
+seq = "std::vector<{type}> {name};"
 2d_seq = "std::vector<std::vector<{type}>> {name};"
 
 # 確保
@@ -353,9 +353,9 @@ seq = "std::vector<{type}> {name}({length});"
 # 入力
 [input]
 #int = "std::cin >> {name};"
-int = "scanf(\"%lld\", &{name});"
+int = "std::scanf(\"%lld\", &{name});"
 #float = "std::cin >> {name};"
-float = "scanf(\"%Lf\", &{name});"
+float = "std::scanf(\"%Lf\", &{name});"
 str = "std::cin >> {name};"
 ```
 

--- a/atcodertools/codegen/code_generators/universal_generator/cpp.toml
+++ b/atcodertools/codegen/code_generators/universal_generator/cpp.toml
@@ -44,7 +44,7 @@ seq = "{name}[{index}]"
 int = "long long {name};"
 float = "long double {name};"
 str = "std::string {name};"
-seq = "std::std::vector<{type}> {name};"
+seq = "std::vector<{type}> {name};"
 2d_seq = "std::vector<std::vector<{type}>> {name};"
 
 # 確保

--- a/atcodertools/codegen/code_generators/universal_generator/cpp.toml
+++ b/atcodertools/codegen/code_generators/universal_generator/cpp.toml
@@ -24,7 +24,7 @@ str = '""'
 # 引数
 [arg]
 int = "long long {name}"
-float = "double {name}"
+float = "long double {name}"
 str = "std::string {name}"
 seq = "std::vector<{type}> {name}"
 2d_seq = "std::vector<std::vector<{type}>> {name}"

--- a/atcodertools/codegen/code_generators/universal_generator/cpp.toml
+++ b/atcodertools/codegen/code_generators/universal_generator/cpp.toml
@@ -60,9 +60,9 @@ seq = "std::vector<{type}> {name}({length});"
 # 入力
 [input]
 #int = "std::cin >> {name};"
-int = "scanf(\"%lld\", &{name});"
+int = "std::scanf(\"%lld\", &{name});"
 #float = "std::cin >> {name};"
-float = "scanf(\"%Lf\", &{name});"
+float = "std::scanf(\"%Lf\", &{name});"
 str = "std::cin >> {name};"
 
 


### PR DESCRIPTION
## Why is this change needed?

- `std::std::vector` is a typo.
- Although non-qualified `scanf` works on many systems, we should use `std::scanf` (unless you do not `using namespace std`). see: [C++17: 20.5.1.2](https://timsong-cpp.github.io/cppwp/n4659/headers#4)
- To be consistent with line 15, we should use `long double` for float arguments.

## What did you implement?

## What behavior do you expect?

I leave these sections blank since it is obvious.
