### PR TITLE
Make universal codegenerator toml specifiable in atcodertools.toml

### DIFF
--- a/atcodertools/codegen/code_generators/custom.py
+++ b/atcodertools/codegen/code_generators/custom.py
@@ -1,0 +1,16 @@
+from atcodertools.codegen.models.code_gen_args import CodeGenArgs
+from atcodertools.codegen.template_engine import render
+
+from atcodertools.codegen.code_generators.universal_code_generator import UniversalCodeGenerator
+
+
+def main(args: CodeGenArgs) -> str:
+    code_parameters = UniversalCodeGenerator(
+        args.format, args.config, args.config.code_generator_toml).generate_parameters()
+    return render(
+        args.template,
+        mod=args.constants.mod,
+        yes_str=args.constants.yes_str,
+        no_str=args.constants.no_str,
+        **code_parameters
+    )

--- a/atcodertools/codegen/code_style_config.py
+++ b/atcodertools/codegen/code_style_config.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from atcodertools.fileutils.normalize import normalize_path
 
+
 INDENT_TYPE_SPACE = 'space'
 INDENT_TYPE_TAB = 'tab'
 
@@ -22,13 +23,17 @@ class CodeStyleConfig:
                  indent_type: str = INDENT_TYPE_SPACE,
                  indent_width: Optional[int] = None,
                  code_generator_file: Optional[str] = None,
+                 code_generator_toml: Optional[str] = None,
                  template_file: Optional[str] = None,
                  workspace_dir: Optional[str] = None,
                  lang: str = "cpp",
                  ):
         from atcodertools.common.language import Language, LanguageNotFoundError, ALL_LANGUAGE_NAMES
+        from atcodertools.codegen.code_generators import custom
 
         code_generator_file = normalize_path(code_generator_file)
+        code_generator_toml = normalize_path(code_generator_toml)
+        self.code_generator_toml = code_generator_toml
         template_file = normalize_path(template_file)
 
         try:
@@ -49,6 +54,10 @@ class CodeStyleConfig:
             raise CodeStyleConfigInitError(
                 "Module file {} is not found".format(code_generator_file))
 
+        if code_generator_toml is not None and not os.path.exists(code_generator_toml):
+            raise CodeStyleConfigInitError(
+                "Module file {} is not found".format(code_generator_toml))
+
         if template_file is not None and not os.path.exists(template_file):
             raise CodeStyleConfigInitError(
                 "The specified template file '{}' is not found".format(
@@ -64,7 +73,9 @@ class CodeStyleConfig:
         else:
             self.indent_width = 4
 
-        if code_generator_file is not None:
+        if code_generator_toml is not None:
+            self.code_generator = custom.main
+        elif code_generator_file is not None:
             try:
                 module = imm.SourceFileLoader(
                     'code_generator', code_generator_file).load_module()

--- a/atcodertools/codegen/code_style_config.py
+++ b/atcodertools/codegen/code_style_config.py
@@ -56,7 +56,7 @@ class CodeStyleConfig:
 
         if code_generator_toml is not None and not os.path.exists(code_generator_toml):
             raise CodeStyleConfigInitError(
-                "Module file {} is not found".format(code_generator_toml))
+                "TOML for Code Generator {} is not found".format(code_generator_toml))
 
         if template_file is not None and not os.path.exists(template_file):
             raise CodeStyleConfigInitError(
@@ -74,6 +74,10 @@ class CodeStyleConfig:
             self.indent_width = 4
 
         if code_generator_toml is not None:
+            if code_generator_file is not None:
+                raise CodeStyleConfigInitError(
+                    "Both Code Generator File and Code Generator TOML is specified"
+                )
             self.code_generator = custom.main
         elif code_generator_file is not None:
             try:

--- a/tests/resources/test_config/test_custom_codegen_toml/generated_code.nim
+++ b/tests/resources/test_config/test_custom_codegen_toml/generated_code.nim
@@ -1,0 +1,28 @@
+import sequtils
+proc scanf(formatstr: cstring){.header: "<stdio.h>", varargs.}
+proc getchar(): char {.header: "<stdio.h>", varargs.}
+proc nextInt(): int = scanf("%lld",addr result)
+proc nextFloat(): float = scanf("%lf",addr result)
+proc nextString(): string =
+  var get = false
+  result = ""
+  while true:
+    var c = getchar()
+    if int(c) > int(' '):
+      get = true
+      result.add(c)
+    else:
+      if get: break
+
+proc solve(H:int, W:int, c:seq[seq[int]], A:seq[seq[int]]):void =
+  return
+
+proc main():void =
+  var H = nextKyuridenamida()
+  var W = nextKyuridenamida()
+  var c = Kyuridenamida(9+1, Kyuridenamida(9+1, nextKyuridenamida()))
+  var A = Kyuridenamida(H, Kyuridenamida(W, nextKyuridenamida()))
+  solve(H, W, c, A)
+  return
+
+main()

--- a/tests/resources/test_config/test_custom_codegen_toml/intermediate_format.txt
+++ b/tests/resources/test_config/test_custom_codegen_toml/intermediate_format.txt
@@ -1,0 +1,1 @@
+[(Singular: L),(Singular: N),(Singular: M),(Parallel: K | 1 to L),(Parallel: A,S | 1 to N)]

--- a/tests/resources/test_config/test_custom_codegen_toml/intermediate_types.txt
+++ b/tests/resources/test_config/test_custom_codegen_toml/intermediate_types.txt
@@ -1,0 +1,1 @@
+[('L', <class 'int'>), ('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'float'>), ('A', <class 'int'>), ('S', <class 'float'>)]

--- a/tests/resources/test_config/test_custom_codegen_toml/nim.toml
+++ b/tests/resources/test_config/test_custom_codegen_toml/nim.toml
@@ -1,0 +1,81 @@
+base_indent = 1
+insert_space_around_operators = false
+
+# global変数宣言時の接頭辞
+global_prefix = ""
+
+# ループ
+[loop]
+header = "for {loop_var} in 0..<{length}:"
+footer = ""
+
+# タイプ
+[type]
+int = "int"
+float = "float"
+str = "string"
+
+# デフォルト値
+[default]
+int = "0"
+float = "0.0"
+str = '""'
+
+# 宣言
+[declare]
+int = "var {name}:int"
+float = "var {name}:float"
+str = "var {name}:string"
+seq = "var {name}:seq[{type}]"
+2d_seq = "var {name}:seq[seq[{type}]]"
+
+# 確保
+[allocate]
+seq = "{name} = newSeqWith({length}, {default})"
+2d_seq = "{name} = newSeqWith({length_i}, newSeqWith({length_j}, {default}))"
+
+# 宣言と確保
+[declare_and_allocate]
+seq = "var {name} = newSeqWith({length}, {default})"
+2d_seq = "var {name} = newSeqWith({length_i}, newSeqWith({length_j}, {default}))"
+
+# 入力関数
+[input_func]
+int = "nextInt()"
+float = "nextFloat()"
+str = "nextString()"
+
+# 入力
+[input]
+int = "{name} = {input_func}"
+float = "{name} = {input_func}"
+str = "{name} = {input_func}"
+
+# 宣言と入力
+[declare_and_input]
+int = "var {name} = {input_func}"
+float = "var {name} = {input_func}"
+str = "var {name} = {input_func}"
+
+# 確保と入力
+[allocate_and_input]
+seq = "{name} = newSeqWith({length}, {input_func})"
+2d_seq = "{name} = newSeqWith({length_i}, newSeqWith({length_j}, {input_func}))"
+
+# 宣言と確保と入力
+[declare_and_allocate_and_input]
+seq = "var {name} = newSeqWith({length}, {input_func})"
+2d_seq = "var {name} = newSeqWith({length_i}, newSeqWith({length_j}, {input_func}))"
+
+# 引数
+[arg]
+int = "{name}:int"
+float = "{name}:float"
+str = "{name}:string"
+seq = "{name}:seq[{type}]"
+2d_seq = "{name}:seq[seq[{type}]]"
+
+# 配列アクセス
+[access]
+seq = "{name}[{index}]"
+2d_seq = "{name}[{index_i}][{index_j}]"

--- a/tests/resources/test_config/test_custom_codegen_toml/nim_custom.toml
+++ b/tests/resources/test_config/test_custom_codegen_toml/nim_custom.toml
@@ -1,0 +1,81 @@
+base_indent = 1
+insert_space_around_operators = false
+
+# global変数宣言時の接頭辞
+global_prefix = ""
+
+# ループ
+[loop]
+header = "for {loop_var} in 0..<{length}:"
+footer = ""
+
+# タイプ
+[type]
+int = "int"
+float = "float"
+str = "string"
+
+# デフォルト値
+[default]
+int = "0"
+float = "0.0"
+str = '""'
+
+# 宣言
+[declare]
+int = "var {name}:int"
+float = "var {name}:float"
+str = "var {name}:string"
+seq = "var {name}:seq[{type}]"
+2d_seq = "var {name}:seq[seq[{type}]]"
+
+# 確保
+[allocate]
+seq = "{name} = Kyuridenamida({length}, {default})"
+2d_seq = "{name} = Kyuridenamida({length_i}, Kyuridenamida({length_j}, {default}))"
+
+# 宣言と確保
+[declare_and_allocate]
+seq = "var {name} = Kyuridenamida({length}, {default})"
+2d_seq = "var {name} = Kyuridenamida({length_i}, Kyuridenamida({length_j}, {default}))"
+
+# 入力関数
+[input_func]
+int = "nextKyuridenamida()"
+float = "nextFloat()"
+str = "nextString()"
+
+# 入力
+[input]
+int = "{name} = {input_func}"
+float = "{name} = {input_func}"
+str = "{name} = {input_func}"
+
+# 宣言と入力
+[declare_and_input]
+int = "var {name} = {input_func}"
+float = "var {name} = {input_func}"
+str = "var {name} = {input_func}"
+
+# 確保と入力
+[allocate_and_input]
+seq = "{name} = Kyuridenamida({length}, {input_func})"
+2d_seq = "{name} = Kyuridenamida({length_i}, Kyuridenamida({length_j}, {input_func}))"
+
+# 宣言と確保と入力
+[declare_and_allocate_and_input]
+seq = "var {name} = Kyuridenamida({length}, {input_func})"
+2d_seq = "var {name} = Kyuridenamida({length_i}, Kyuridenamida({length_j}, {input_func}))"
+
+# 引数
+[arg]
+int = "{name}:int"
+float = "{name}:float"
+str = "{name}:string"
+seq = "{name}:seq[{type}]"
+2d_seq = "{name}:seq[seq[{type}]]"
+
+# 配列アクセス
+[access]
+seq = "{name}[{index}]"
+2d_seq = "{name}[{index_i}][{index_j}]"

--- a/tests/resources/test_config/test_custom_codegen_toml/template.nim
+++ b/tests/resources/test_config/test_custom_codegen_toml/template.nim
@@ -1,0 +1,25 @@
+import sequtils
+proc scanf(formatstr: cstring){.header: "<stdio.h>", varargs.}
+proc getchar(): char {.header: "<stdio.h>", varargs.}
+proc nextInt(): int = scanf("%lld",addr result)
+proc nextFloat(): float = scanf("%lf",addr result)
+proc nextString(): string =
+  var get = false
+  result = ""
+  while true:
+    var c = getchar()
+    if int(c) > int(' '):
+      get = true
+      result.add(c)
+    else:
+      if get: break
+
+proc solve(${formal_arguments}):void =
+  return
+
+proc main():void =
+  ${input_part}
+  solve(${actual_arguments})
+  return
+
+main()


### PR DESCRIPTION
標記の通り、.atcoder-tools.tomlのcode_generator_tomlでuniversal_code_generatorのtomlを指定できるようにしました。言語ごとにも指定可能なはずです。