### PR TITLE
enable compiler config by toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ code_generator_file="~/custom_code_generator.py"
 [postprocess]
 exec_on_each_problem_dir='clang-format -i ./*.cpp'
 exec_on_contest_dir='touch CMakeLists.txt'
+[compiler]
+compile_command='g++ main.cpp -o main -std=c++17'
+compile_only_when_diff_detected=true
 [tester]
 compile_before_testing=true
 compile_only_when_diff_detected=true

--- a/atcodertools/config/compiler_config.py
+++ b/atcodertools/config/compiler_config.py
@@ -1,0 +1,8 @@
+class CompilerConfig:
+
+    def __init__(self,
+                 compile_only_when_diff_detected: bool = False,
+                 compile_command: str = None
+                 ):
+        self.compile_only_when_diff_detected = compile_only_when_diff_detected
+        self.compile_command = compile_command

--- a/atcodertools/config/config.py
+++ b/atcodertools/config/config.py
@@ -105,11 +105,12 @@ class Config:
                                                          skip_existing_problems=args.skip_existing_problems))
             result.etc_config = EtcConfig(**etc_config_dic)
         if ConfigType.COMPILER in get_config_type:
-            compiler_config_dic = get_config_dic(config_dic, ConfigType.COMPILER)
+            compiler_config_dic = get_config_dic(
+                config_dic, ConfigType.COMPILER)
             if args:
-                compiler_config_dic = _update_config_dict(compiler_config_dic, dict(
-                                                         compile_only_when_diff_detected=args.compile_only_when_diff_detected,
-                                                         compile_command=args.compile_command))
+                compiler_config_dic = _update_config_dict(compiler_config_dic,
+                                                          dict(compile_only_when_diff_detected=args.compile_only_when_diff_detected,
+                                                               compile_command=args.compile_command))
             result.compiler_config = CompilerConfig(**compiler_config_dic)
 
         return result

--- a/atcodertools/config/config.py
+++ b/atcodertools/config/config.py
@@ -8,6 +8,7 @@ from atcodertools.codegen.code_style_config import CodeStyleConfig
 from atcodertools.config.etc_config import EtcConfig
 from atcodertools.config.postprocess_config import PostprocessConfig
 from atcodertools.config.tester_config import TesterConfig
+from atcodertools.config.compiler_config import CompilerConfig
 
 
 class ConfigType(Enum):
@@ -15,6 +16,7 @@ class ConfigType(Enum):
     POSTPROCESS = "postprocess"
     TESTER = "tester"
     ETC = "etc"
+    COMPILER = "compiler"
 
 
 def _update_config_dict(target_dic: Dict[str, Any], update_dic: Dict[str, Any]):
@@ -44,7 +46,8 @@ class Config:
                  code_style_config: CodeStyleConfig = CodeStyleConfig(),
                  postprocess_config: PostprocessConfig = PostprocessConfig(),
                  tester_config: TesterConfig = TesterConfig(),
-                 etc_config: EtcConfig = EtcConfig()
+                 etc_config: EtcConfig = EtcConfig(),
+                 compiler_config: CompilerConfig = CompilerConfig()
                  ):
         self.code_style_config = code_style_config
         self.postprocess_config = postprocess_config
@@ -101,5 +104,12 @@ class Config:
                                                          save_no_session_cache=args.save_no_session_cache,
                                                          skip_existing_problems=args.skip_existing_problems))
             result.etc_config = EtcConfig(**etc_config_dic)
+        if ConfigType.COMPILER in get_config_type:
+            compiler_config_dic = get_config_dic(config_dic, ConfigType.COMPILER)
+            if args:
+                compiler_config_dic = _update_config_dict(compiler_config_dic, dict(
+                                                         compile_only_when_diff_detected=args.compile_only_when_diff_detected,
+                                                         compile_command=args.compile_command))
+            result.compiler_config = CompilerConfig(**compiler_config_dic)
 
         return result

--- a/atcodertools/tools/compiler.py
+++ b/atcodertools/tools/compiler.py
@@ -61,9 +61,9 @@ def main(prog, args):
 
     parser.add_argument('--compile-only-when-diff-detected',
                         help='compile only when diff detected [true, false]'
-                             ' [Default]: true',
+                             ' [Default]: false',
                         type=bool,
-                        default=False)
+                        default=None)
 
     parser.add_argument("--config",
                         help="File path to your config file\n{0}{1}".format("[Default (Primary)] {}\n".format(

--- a/tests/resources/test_config/compiler_options.toml
+++ b/tests/resources/test_config/compiler_options.toml
@@ -1,0 +1,5 @@
+[codestyle]
+indent_width = 8
+[compiler]
+compile_command='g++ main.cpp -o main -std=c++17'
+compile_only_when_diff_detected=true

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+import shutil
+import tempfile
+
+from atcodertools.tools import compiler
+
+RESOURCE_DIR = os.path.abspath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "./resources/test_tester/"))
+
+
+class TestTester(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def test_compiler(self):
+        test_dir = os.path.join(self.temp_dir, "test")
+        shutil.copytree(os.path.join(
+            RESOURCE_DIR, "test_compiler_and_tester"), test_dir)
+        os.chdir(test_dir)
+        compiler.main(
+            '', ["--compile-command", "touch compile-command-success"])
+        lst = os.listdir('./')
+        self.assertTrue("compile-command-success" in lst)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,6 +127,18 @@ class TestConfig(unittest.TestCase):
         except CodeStyleConfigInitError:
             pass
 
+    def test_load_config_compiler(self):
+        os.chdir(RESOURCE_DIR)
+
+        with open(os.path.join(RESOURCE_DIR, "compiler_options.toml"), 'r') as f:
+            config = Config.load(
+                f, {ConfigType.CODESTYLE, ConfigType.COMPILER})
+
+        self.assertEqual(
+            True, config.compiler_config.compile_only_when_diff_detected)
+        self.assertEqual('g++ main.cpp -o main -std=c++17',
+                         config.compiler_config.compile_command)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why is this change needed?


I want to specify the options of ``atcoder-tools compile`` command in atcoder-tools.toml file.

(Japanese)
atcoder-tools compileコマンドのオプション(compile_command, compile_only_when_diff_detected)について、tomlファイルで設定可能にしたいため。

## What did you implement?

- Add ``compiler_config.py`` (refer to tester_config.py).
- Add function importing config from ``compiler`` directive in atcoder-tools.toml on ``config.py``.
- Add function setting config from atcoder-tools.toml on ``compiler.py``.

(Japanese) 
- compiler_config.pyを新規作成(tester_config.pyを参考に)。
- config.pyに、tomlファイルにおけるcompilerディレクティブを読み込む設定を追加。
- compiler.pyに、tomlからのconfigを設定する処理を追加。

## What behavior do you expect?

When you add the following config in atcoder-tools.toml, you can get the result in the case of setting the command options of ``atcoder-tools compile --compile-command 'g++ main.cpp -o main -std=c++17' --compile-only-when-diff-detected true``.
```
[compiler]
compile_command='g++ main.cpp -o main -std=c++17'
compile_only_when_diff_detected=true
```

(Japanese)
atcoder-tools.tomlファイルに、下記設定を追加することで、``atcoder-tools compiler``のcommand optionで指定した場合と同様の結果が得られる。
