### PR TITLE
Fix #240 Add missing return statement in submit_main

### DIFF
--- a/atcodertools/tools/submit.py
+++ b/atcodertools/tools/submit.py
@@ -125,6 +125,8 @@ def main(prog, args, credential_supplier=None, use_local_session_cache=True) -> 
             with_color("Done!", Fore.LIGHTGREEN_EX),
             metadata.problem.contest.get_submissions_url(submission)))
 
+    return True
+
 
 if __name__ == "__main__":
     main(sys.argv[0], sys.argv[1:])


### PR DESCRIPTION
## Why is this change needed?

Please see #240.
(In brief: `atcoder-tools submit` exits with a non-zero exit code regardless of whether the submission was successful or not.)

## What did you implement?

I added `return True` at the end of the `main` function in `submit.py`.

## What behavior do you expect?

`atcoder-tools submit` exits successfully if the submission is successful or the solution does not pass the test (WA, TLE, RE).