### PR TITLE
Refactor user config path setting

### DIFF
--- a/atcodertools/tools/compiler.py
+++ b/atcodertools/tools/compiler.py
@@ -1,16 +1,13 @@
 #!/usr/bin/python3
 import argparse
-from os.path import expanduser
 
 from atcodertools.executils.run_command import run_command_with_returncode
 from atcodertools.tools.models.metadata import Metadata
 from atcodertools.common.language import Language
 import os
 import pathlib
-from atcodertools.config.config import Config, ConfigType
+from atcodertools.config.config import Config, ConfigType, USER_CONFIG_PATH
 from atcodertools.tools import get_default_config_path
-
-USER_CONFIG_PATH = os.path.join(expanduser("~"), ".atcodertools.toml")
 
 
 class BadStatusCodeException(Exception):

--- a/atcodertools/tools/envgen.py
+++ b/atcodertools/tools/envgen.py
@@ -5,7 +5,6 @@ import shutil
 import sys
 import traceback
 from multiprocessing import Pool, cpu_count
-from os.path import expanduser
 import time
 from typing import Tuple
 
@@ -28,7 +27,7 @@ from atcodertools.fmtprediction.predict_format import NoPredictionResultError, \
 from atcodertools.tools import get_default_config_path
 from atcodertools.tools.models.metadata import Metadata
 from atcodertools.tools.utils import with_color
-from atcodertools.config.config import ConfigType
+from atcodertools.config.config import ConfigType, USER_CONFIG_PATH
 
 
 class BannedFileDetectedError(Exception):
@@ -217,10 +216,6 @@ def prepare_contest(atcoder_client: AtCoderClient,
                                           config.postprocess_config.exec_cmd_on_contest_dir))
         config.postprocess_config.execute_on_contest_dir(
             contest_dir_path)
-
-
-USER_CONFIG_PATH = os.path.join(
-    expanduser("~"), ".atcodertools.toml")
 
 
 def get_config(args: argparse.Namespace) -> Config:


### PR DESCRIPTION
## Why is this change needed?
 
Refactoring because the following source code does not use USER_CONFIG_PATH in atcodertools/config/config.py.
atcodertools/tools/compiler.py
atcodertools/tools/envgen.py
 
_(Japanese)
下記のソースコードでは、atcodertools/config/config.pyのUSER_CONFIG_PATHを使用していないためリファクタリング。
atcodertools/tools/compiler.py
atcodertools/tools/envgen.py
 
## What did you implement?
 
Replaced the USER_CONFIG_PATH defined for each source code with the USER_CONFIG_PATH in atcodertools/config/config.py.
 
_(Japanese) 
 
ソースコード毎に定義してあるUSER_CONFIG_PATHを、atcodertools/config/config.py のUSER_CONFIG_PATHに置き換えた。
 
## What behavior do you expect?

If the `atcoder-tools gen` and `atcoder-tools compile` tests pass, you're good to go.
_(Japanese)

`atcoder-tools gen`と`atcoder-tools compile`のテストが通ればOK
