### PR TITLE
feat: fix markupsafe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requests = "^2.25.1"
 colorama = "^0.4.4"
 toml = "^0.10.2"
 Jinja2 = "^2.11.3"
+markupsafe = "2.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
## Why is this change needed?

close #263 

_A simple background is fine. e.g. I want to do YYYY for the situation of XXXX._ 

_(Japanese)
なぜこの変更が必要か? 
簡潔なもので良い。
(例) ○○の状況で△△できるようにしたいから_ 

ryeにてサンプルコマンドを入力するとエラーが出たため。markupsafe3系では該当の関数が削除されている。
```
kyoupuro on  main [!] is 📦 v0.1.0 via 🐍 v3.11.4 (kyoupuro) on ☁️   
❯ atcoder-tools gen agc001
Traceback (most recent call last):
  File "/Users/user/work/private/kyoupuro/.venv/bin/atcoder-tools", line 5, in <module>
    from atcodertools.atcoder_tools import main
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/atcodertools/atcoder_tools.py", line 8, in <module>
    from atcodertools.tools.envgen import main as envgen_main
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/atcodertools/tools/envgen.py", line 14, in <module>
    from atcodertools.client.atcoder import AtCoderClient, Contest, LoginError, PageNotFoundError
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/atcodertools/client/atcoder.py", line 15, in <module>
    from atcodertools.common.language import Language
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/atcodertools/common/language.py", line 4, in <module>
    from atcodertools.codegen.code_generators import cpp, java, rust, python, nim, d, cs, swift, go, julia
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/atcodertools/codegen/code_generators/cpp.py", line 2, in <module>
    from atcodertools.codegen.template_engine import render
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/atcodertools/codegen/template_engine.py", line 5, in <module>
    from jinja2 import Environment
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/markupsafe/__init__.py)
kyoupuro
```

## What did you implement?

_A minimal highlight of your change is fine. e.g. Add parameter XXXX in the config._

_(Japanese) 
何をしたか?
コードを読む際に手助けになる程度で良い。
(例) ○○というconfigのパラメータを追加した。_

pyproject.tomlにmarkupsafeを固定した
```
markupsafe==2.0.1
```

## What behavior do you expect?

_This is required for the verification of your functionality by the maintainer. 
e.g. When you have file XXX and execute command YYY, then you will see ZZZ in the console output._

_(Japanese)
どういう挙動が期待されるか?
メンテナが手元で動作チェックする時に必要。
(例) ☓☓というファイルがある状態で○○というコマンドを実行した際に△△という出力がコンソールにされる。_

markupsafeがない問題が解決される。
```
kyoupuro/src/kyoupuro on  main [!] via 🐍 v3.11.4 (kyoupuro) on ☁️   took 4s 
❯ atcoder-tools gen agc001
2024-10-12 23:48:48,819 INFO: Going to load /Users/user/work/private/kyoupuro/.venv/lib/python3.11/site-packages/atcodertools/tools/atcodertools-default.toml as config
AtCoder username: 
```