### PR TITLE
Update Python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.11' ]
+        python-version: [ '3.9', '3.11' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Why is this change needed?

PoetryがPython 3.9以降となり、CIが落ちているため更新

https://python-poetry.org/docs/
> Poetry requires Python 3.9+

## What did you implement?

- [ ] Python 3.8 -> 3.9

## What behavior do you expect?

- [ ] CI pass
