### PR TITLE
feat: add CAPTCHA detection for submissions

### DIFF
--- a/atcodertools/client/atcoder.py
+++ b/atcodertools/client/atcoder.py
@@ -25,6 +25,10 @@ class PageNotFoundError(Exception):
     pass
 
 
+class CaptchaError(Exception):
+    pass
+
+
 default_cookie_path = get_cache_file_path('cookie.txt')
 
 
@@ -166,6 +170,9 @@ class AtCoderClient(metaclass=Singleton):
             lang_option_pattern = lang.submission_lang_pattern
 
         resp = self._request(contest.get_submit_url())
+
+        if "https://challenges.cloudflare.com" in resp.text:
+            raise CaptchaError("CAPTCHA detected. Cannot submit automatically. Please submit manually through the web interface.")
 
         soup = BeautifulSoup(resp.text, "html.parser")
         session_id = soup.find("input", attrs={"type": "hidden"}).get("value")

--- a/atcodertools/client/atcoder.py
+++ b/atcodertools/client/atcoder.py
@@ -172,7 +172,8 @@ class AtCoderClient(metaclass=Singleton):
         resp = self._request(contest.get_submit_url())
 
         if "https://challenges.cloudflare.com" in resp.text:
-            raise CaptchaError("CAPTCHA detected. Cannot submit automatically. Please submit manually through the web interface.")
+            raise CaptchaError(
+                "CAPTCHA detected. Cannot submit automatically. Please submit manually through the web interface.")
 
         soup = BeautifulSoup(resp.text, "html.parser")
         session_id = soup.find("input", attrs={"type": "hidden"}).get("value")

--- a/atcodertools/tools/submit.py
+++ b/atcodertools/tools/submit.py
@@ -8,7 +8,7 @@ from colorama import Fore
 from atcodertools.tools.tester import USER_FACING_JUDGE_TYPE_LIST, DEFAULT_EPS
 from atcodertools.tools.utils import with_color
 
-from atcodertools.client.atcoder import AtCoderClient, LoginError
+from atcodertools.client.atcoder import AtCoderClient, LoginError, CaptchaError
 from atcodertools.tools import tester
 from atcodertools.common.logging import logger
 from atcodertools.config.config import Config, ConfigType, USER_CONFIG_PATH
@@ -170,11 +170,15 @@ def main(prog, args, credential_supplier=None, use_local_session_cache=True, cli
                 logger.warning("code wasn't recognized as {}".format(encoding))
         logger.info(
             "Submitting {} as {}".format(code_path, metadata.lang.name))
-        submission = client.submit_source_code(
-            metadata.problem.contest, metadata.problem, metadata.lang, source)
-        logger.info("{} {}".format(
-            with_color("Done!", Fore.LIGHTGREEN_EX),
-            metadata.problem.contest.get_submissions_url(submission)))
+        try:
+            submission = client.submit_source_code(
+                metadata.problem.contest, metadata.problem, metadata.lang, source)
+            logger.info("{} {}".format(
+                with_color("Done!", Fore.LIGHTGREEN_EX),
+                metadata.problem.contest.get_submissions_url(submission)))
+        except CaptchaError as e:
+            logger.error(with_color(str(e), Fore.LIGHTRED_EX))
+            return False
         if config.submit_config.exec_after_submit:
             run_command(config.submit_config.exec_after_submit, args.dir)
 

--- a/tests/resources/test_atcoder_client_mock/submit/after_get.html
+++ b/tests/resources/test_atcoder_client_mock/submit/after_get.html
@@ -1084,12 +1084,6 @@
                     <div class="form-group">
                         <label class="control-label col-sm-3 col-md-2"></label>
                         <div class="col-sm-5">
-
-                            <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-
-                            <div class="cf-challenge" data-sitekey="0x4AAAAAAA6HJUmmLP7mLxx0" data-theme="light"></div>
-
-
                             <button id="submit" type="submit" class="btn btn-primary">提出</button>
                         </div>
                     </div>

--- a/tests/resources/test_atcoder_client_mock/submit/after_get_with_captcha.html
+++ b/tests/resources/test_atcoder_client_mock/submit/after_get_with_captcha.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>提出 - AtCoder Regular Contest 001</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Language" content="ja">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="format-detection" content="telephone=no">
+    <meta name="google-site-verification" content="nXGC_JxO0yoP1qBzMnYD_xgufO6leSLw1kyNo2HZltM" />
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RC512FD18N"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('set', 'user_properties', {
+            'login_status': 'logged_in',
+        });
+        gtag('config', 'G-RC512FD18N');
+    </script>
+
+    <meta name="description" content="プログラミング初級者から上級者まで楽しめる、競技プログラミングコンテストサイト「AtCoder」。オンラインで毎週開催プログラミングコンテストを開催しています。競技プログラミングを用いて、客観的に自分のスキルを計ることのできるサービスです。">
+    <meta name="author" content="AtCoder Inc.">
+
+    <meta property="og:site_name" content="AtCoder">
+    <meta property="og:title" content="提出 - AtCoder Regular Contest 001" />
+    <meta property="og:description" content="プログラミング初級者から上級者まで楽しめる、競技プログラミングコンテストサイト「AtCoder」。オンラインで毎週開催プログラミングコンテストを開催しています。競技プログラミングを用いて、客観的に自分のスキルを計ることのできるサービスです。" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://atcoder.jp/contests/arc001/submit" />
+    <meta property="og:image" content="https://img.atcoder.jp/assets/atcoder.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@atcoder" />
+
+    <meta property="twitter:title" content="提出 - AtCoder Regular Contest 001" />
+
+    <link href="//fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css">
+    <link rel="stylesheet" type="text/css" href="//img.atcoder.jp/public/20e0d71/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="//img.atcoder.jp/public/20e0d71/css/base.css">
+    <link rel="shortcut icon" type="image/png" href="//img.atcoder.jp/assets/favicon.png">
+    <link rel="apple-touch-icon" href="//img.atcoder.jp/assets/atcoder.png">
+    <script src="//img.atcoder.jp/public/20e0d71/js/lib/jquery-1.9.1.min.js"></script>
+    <script src="//img.atcoder.jp/public/20e0d71/js/lib/bootstrap.min.js"></script>
+    <script src="//img.atcoder.jp/public/20e0d71/js/cdn/js.cookie.min.js"></script>
+    <script src="//img.atcoder.jp/public/20e0d71/js/cdn/moment.min.js"></script>
+    <script src="//img.atcoder.jp/public/20e0d71/js/cdn/moment_js-ja.js"></script>
+    <script>
+        var LANG = "ja";
+        var userScreenName = "kyuridenamida";
+        var csrfToken = "s7aDUI13R8FHa5mglSOQJptstVbvnjYhaiX0gYK2LS0="
+    </script>
+    <script src="//img.atcoder.jp/public/20e0d71/js/utils.js"></script>
+
+    <script src="//img.atcoder.jp/public/20e0d71/js/contest.js"></script>
+    <link href="//img.atcoder.jp/public/20e0d71/css/contest.css" rel="stylesheet" />
+    <script>
+        var contestScreenName = "arc001";
+        var remainingText = "残り時間";
+        var countDownText = "開始まであと";
+        var startTime = moment("2012-04-14T21:00:00+09:00");
+        var endTime = moment("2012-04-15T02:00:00+09:00");
+    </script>
+    <style></style>
+
+    <link href="//img.atcoder.jp/public/20e0d71/css/cdn/select2.min.css" rel="stylesheet" />
+    <link href="//img.atcoder.jp/public/20e0d71/css/cdn/select2-bootstrap.min.css" rel="stylesheet" />
+    <script src="//img.atcoder.jp/public/20e0d71/js/lib/select2.min.js"></script>
+
+    <script src="//img.atcoder.jp/public/20e0d71/js/ace/ace.js"></script>
+    <script src="//img.atcoder.jp/public/20e0d71/js/ace/ext-language_tools.js"></script>
+
+    <script src="//img.atcoder.jp/public/20e0d71/js/base.js"></script>
+</head>
+
+<body>
+
+<script type="text/javascript">
+    var __pParams = __pParams || [];
+    __pParams.push({client_id: '468', c_1: 'atcodercontest', c_2: 'ClientSite'});
+</script>
+<script type="text/javascript" src="https://cdn.d2-apps.net/js/tr.js" async></script>
+
+<div id="main-div" class="float-container">
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+        <div class="container-fluid">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-expanded="false">
+                    <span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="/home"></a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar-collapse">
+                <ul class="nav navbar-nav">
+                    <li><a class="contest-title" href="/contests/arc001">AtCoder Regular Contest 001</a></li>
+                </ul>
+                <ul class="nav navbar-nav navbar-right">
+                    <li class="dropdown">
+                        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                            <img src='//img.atcoder.jp/assets/top/img/flag-lang/ja.png'> 日本語 <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <li><a href="/contests/arc001/submit?lang=ja"><img src='//img.atcoder.jp/assets/top/img/flag-lang/ja.png'> 日本語</a></li>
+                            <li><a href="/contests/arc001/submit?lang=en"><img src='//img.atcoder.jp/assets/top/img/flag-lang/en.png'> English</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="dropdown">
+                        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                            <span class="glyphicon glyphicon-cog" aria-hidden="true"></span> sigma425 (Contestant) <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            <li><a href="/users/kyuridenamida"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> マイプロフィール</a></li>
+                            <li class="divider"></li>
+                            <li><a href="/settings"><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> 基本設定</a></li>
+                            <li><a href="/settings/icon"><span class="glyphicon glyphicon-picture" aria-hidden="true"></span> アイコン設定</a></li>
+                            <li><a href="/settings/password"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span> パスワードの変更</a></li>
+                            <li><a href="/settings/fav"><span class="glyphicon glyphicon-star" aria-hidden="true"></span> お気に入り管理</a></li>
+
+                            <li class="divider"></li>
+                            <li><a href="javascript:void(form_logout.submit())"><span class="glyphicon glyphicon-log-out" aria-hidden="true"></span> ログアウト</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <form method="POST" name="form_logout" action="/logout?continue=https%3A%2F%2Fatcoder.jp%2Fcontests%2Farc001%2Fsubmit">
+        <input type="hidden" name="csrf_token" value="s7aDUI13R8FHa5mglSOQJptstVbvnjYhaiX0gYK2LS0=" />
+    </form>
+    <div id="main-container" class="container" style="padding-top:50px;">
+        <div class="row">
+            <div id="contest-nav-tabs" class="col-sm-12 mb-2 cnvtb-fixed">
+                <div>
+                    <small class="contest-duration">
+                        コンテスト時間:
+                        <a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20120414T2100&p1=248' target='blank'><time class='fixtime fixtime-full'>2012-04-14 21:00:00+0900</time></a> ~ <a href='http://www.timeanddate.com/worldclock/fixedtime.html?iso=20120415T0200&p1=248' target='blank'><time class='fixtime fixtime-full'>2012-04-15 02:00:00+0900</time></a>
+                        (300分)
+                    </small>
+                    <small class="back-to-home pull-right"><a href="/home">AtCoderホームへ戻る</a></small>
+                </div>
+                <ul class="nav nav-tabs">
+                    <li><a href="/contests/arc001"><span class="glyphicon glyphicon-home" aria-hidden="true"></span> トップ</a></li>
+                    <li><a href="/contests/arc001/tasks"><span class="glyphicon glyphicon-tasks" aria-hidden="true"></span> 問題</a></li>
+                    <li><a href="/contests/arc001/clarifications"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span> 質問 <span id="clar-badge" class="badge" ></span></a></li>
+                    <li class="active"><a href="/contests/arc001/submit"><span class="glyphicon glyphicon-send" aria-hidden="true"></span> 提出</a></li>
+                    <li>
+                        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-list" aria-hidden="true"></span> 提出結果<span class="caret"></span></a>
+                        <ul class="dropdown-menu">
+                            <li><a href="/contests/arc001/submissions"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> すべての提出</a></li>
+                            <li><a href="/contests/arc001/submissions/me"><span class="glyphicon glyphicon-user" aria-hidden="true"></span> 自分の提出</a></li>
+                            <li class="divider"></li>
+                            <li><a href="/contests/arc001/score"><span class="glyphicon glyphicon-dashboard" aria-hidden="true"></span> 自分の得点状況</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="/contests/arc001/standings"><span class="glyphicon glyphicon-sort-by-attributes-alt" aria-hidden="true"></span> 順位表</a></li>
+                    <li><a href="/contests/arc001/standings/virtual"><span class="glyphicon glyphicon-sort-by-attributes-alt" aria-hidden="true"></span> バーチャル順位表</a></li>
+                    <li><a href="/contests/arc001/custom_test"><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> コードテスト</a></li>
+                    <li><a href="/contests/arc001/editorial"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> 解説</a></li>
+                    <li class="pull-right"><a id="fix-cnvtb" href="javascript:void(0)"><span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span></a></li>
+                </ul>
+            </div>
+            <div class="col-sm-12">
+                <h2>提出</h2>
+                <hr>
+
+                <form class="form-horizontal form-code-submit" action="/contests/arc001/submit" method="POST">
+                    <div class="form-group ">
+                        <label class="control-label col-sm-3 col-md-2" for="select-task">問題</label>
+                        <div class="col-sm-5">
+                            <select class="form-control" id="select-task" name="data.TaskScreenName">
+                                <option value="arc001_1">A - センター採点</option>
+                                <option value="arc001_2">B - リモコン</option>
+                                <option value="arc001_3">C - パズルのお手伝い</option>
+                                <option value="arc001_4">D - レースゲーム</option>
+                            </select>
+                            <span class="error"></span>
+                        </div>
+                    </div>
+
+                    <div class="form-group ">
+                        <label class="control-label col-sm-3 col-md-2" for="select-lang">言語</label>
+                        <div id="select-lang" class="col-sm-5" data-name="data.LanguageId" style="display:none;">
+                            <div id="select-lang-arc001_1">
+                                <select class="form-control" data-placeholder="-" style="width:300px;">
+                                    <option></option>
+                                    <option value="5001" data-ace-mode="c_cpp">C++ 20 (gcc 12.2)</option>
+                                    <option value="5055" data-ace-mode="python">Python (CPython 3.11.4)</option>
+                                </select>
+                            </div>
+                            <span class="error"></span>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="col-sm-3 col-md-2 editor-label">
+                            <label class="control-label" for="sourceCode">ソースコード</label>
+                            <div class="editor-buttons">
+                                <button id="btn-open-file" type="button" class="btn btn-default btn-sm">
+                                    <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span> &nbsp; ファイルを開く
+                                </button>
+                                <button id="btn-customize" type="button" class="btn btn-default btn-sm">
+                                    <span class="glyphicon glyphicon-cog" aria-hidden="true"></span> &nbsp; カスタマイズ
+                                </button>
+                            </div>
+                        </div>
+                        <div class="col-sm-9 col-md-10" id="sourceCode">
+                            <div id="editor"></div>
+                            <textarea id="plain-textarea" class="form-control" style="display:none;" name="sourceCode"></textarea>
+                            <p>
+                                <span class="gray">※ 512 KiB まで</span><br>
+                            </p>
+                        </div>
+                        <input id="input-open-file" type="file" style="display:none;">
+                    </div>
+
+                    <input type="hidden" name="csrf_token" value="s7aDUI13R8FHa5mglSOQJptstVbvnjYhaiX0gYK2LS0=" />
+                    <div class="form-group">
+                        <label class="control-label col-sm-3 col-md-2"></label>
+                        <div class="col-sm-5">
+                            <!-- CAPTCHA section with Cloudflare challenge -->
+                            <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+                            <div class="cf-challenge" data-sitekey="0x4AAAAAAA6HJUmmLP7mLxx0" data-theme="light"></div>
+
+                            <button id="submit" type="submit" class="btn btn-primary">提出</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <hr>
+        
+        <div class="a2a_kit a2a_kit_size_20 a2a_default_style pull-right" data-a2a-url="https://atcoder.jp/contests/arc001/submit?lang=ja" data-a2a-title="提出 - AtCoder Regular Contest 001">
+            <a class="a2a_button_facebook"></a>
+            <a class="a2a_button_twitter"></a>
+            <a class="a2a_button_hatena"></a>
+            <a class="a2a_dd" href="https://www.addtoany.com/share"></a>
+        </div>
+
+        <script async src="//static.addtoany.com/menu/page.js"></script>
+    </div>
+    <hr>
+</div>
+
+<div class="container" style="margin-bottom: 80px;">
+    <footer class="footer">
+        <ul>
+            <li><a href="/contests/arc001/rules">ルール</a></li>
+            <li><a href="/contests/arc001/glossary">用語集</a></li>
+        </ul>
+        <ul>
+            <li><a href="/tos">利用規約</a></li>
+            <li><a href="/privacy">プライバシーポリシー</a></li>
+            <li><a href="/personal">個人情報保護方針</a></li>
+            <li><a href="/company">企業情報</a></li>
+            <li><a href="/faq">よくある質問</a></li>
+            <li><a href="/contact">お問い合わせ</a></li>
+            <li><a href="/documents/request">資料請求</a></li>
+        </ul>
+        <div class="text-center">
+            <small id="copyright">Copyright Since 2012 &copy;<a href="http://atcoder.co.jp">AtCoder Inc.</a> All rights reserved.</small>
+        </div>
+    </footer>
+</div>
+<p id="fixed-server-timer" class="contest-timer"></p>
+<div id="scroll-page-top" style="display:none;"><span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span> ページトップ</div>
+
+</body>
+</html>

--- a/tests/test_atcoder_client_mock.py
+++ b/tests/test_atcoder_client_mock.py
@@ -4,7 +4,7 @@ import unittest
 import shutil
 from typing import Dict
 
-from atcodertools.client.atcoder import AtCoderClient
+from atcodertools.client.atcoder import AtCoderClient, CaptchaError
 from atcodertools.client.models.contest import Contest
 from atcodertools.client.models.problem import Problem
 from atcodertools.common.language import CPP
@@ -90,6 +90,21 @@ class TestAtCoderClientMock(unittest.TestCase):
                 contest, problem, lang, "x")
             self.assertEqual(13269587, submission.submission_id)
             self.assertEqual("arc001_1", submission.problem_id)
+
+    @restore_client_after_run
+    def test_submit_source_code_with_captcha_html_file(self):
+        contest = Contest("arc001")
+        problem = Problem(contest, "A", "arc001_1")
+
+        self.client._request = create_fake_request_func(
+            {contest.get_submit_url(): fake_resp("submit/after_get_with_captcha.html")}
+        )
+
+        with self.assertRaises(CaptchaError) as context:
+            self.client.submit_source_code(contest, problem, CPP, "x")
+
+        self.assertIn("CAPTCHA detected", str(context.exception))
+        self.assertIn("Cannot submit automatically", str(context.exception))
 
     @restore_client_after_run
     def test_login_success(self):

--- a/tests/test_atcoder_client_mock.py
+++ b/tests/test_atcoder_client_mock.py
@@ -97,7 +97,8 @@ class TestAtCoderClientMock(unittest.TestCase):
         problem = Problem(contest, "A", "arc001_1")
 
         self.client._request = create_fake_request_func(
-            {contest.get_submit_url(): fake_resp("submit/after_get_with_captcha.html")}
+            {contest.get_submit_url(): fake_resp(
+                "submit/after_get_with_captcha.html")}
         )
 
         with self.assertRaises(CaptchaError) as context:


### PR DESCRIPTION
## Why is this change needed?

  AtCoderでCAPTCHA（reCAPTCHA/Turnstile）が表示される状況で自動提出が失敗するため、適切なエラーハンドリングが必要だから

##  What did you implement?

  - CaptchaError例外クラスを追加
  - 提出ページでCloudflare CAPTCHAを検出する機能を追加
  - CAPTCHA検出時に適切なエラーメッセージを表示する処理を追加
  - CAPTCHA検出のテストケースを追加

##  What behavior do you expect?

  CAPTCHA付きの提出ページが返された状態でatcoder-tools submitコマンドを実行した際に、「CAPTCHA detected. Cannot submit automatically. Please submit manually through the web interface.」というエラーメッセージがコンソールに表示される。
