### PR TITLE
fix/ahc-parsing-error

### DIFF
--- a/atcodertools/client/models/problem_content.py
+++ b/atcodertools/client/models/problem_content.py
@@ -113,7 +113,7 @@ class ProblemContent:
 
             if section_title.startswith("入力例"):
                 input_tags.append(tag.find('pre'))
-            elif section_title.startswith("入力"):
+            elif section_title == "入力":
                 input_format_tag = tag.find('pre')
 
             if section_title.startswith("出力例"):


### PR DESCRIPTION
## Why is this change needed?

To fix a `SampleDetectionError` that occurs when running `atcoder-tools gen ahc`.
In AHC, there is a section titled "入力生成方法" (Input Generation Method). The current parser incorrectly identifies this as the "Input Format" section because `startswith("入力")` matches "入力生成方法", causing the correct input format to be overwritten.

_(Japanese)
`atcoder-tools gen ahc` を実行した際に発生する `SampleDetectionError` を修正するため。
AHCには「入力生成方法」というセクションがあり、`startswith("入力")` という条件だとこれにもマッチしてしまい、正しい入力形式の情報が上書きされてエラーになっていました。_

## What did you implement?

Changed the condition for detecting the Input Format section in `atcodertools/client/models/problem_content.py` from `startswith("入力")` to an exact match `== "入力"`.
This ensures that sections like "入力生成方法" are strictly excluded.

_(Japanese)
`atcodertools/client/models/problem_content.py` における入力形式セクションの判定条件を、`startswith("入力")` から完全一致の `== "入力"` に変更しました。
これにより、「入力生成方法」のようなセクションが誤って検出されるのを防ぎます。_

## What behavior do you expect?

When executing the command `atcoder-tools gen ahc001`, the tool should successfully download samples without raising `SampleDetectionError`.

_(Japanese)
`atcoder-tools gen ahc001` コマンドを実行した際に、`SampleDetectionError` が発生せず、正常にサンプルがダウンロードされること。_