### PR TITLE
multi_case_layoutの公開API名を整理

### DIFF
--- a/atcodertools/fmtprediction/multi_case_layout.py
+++ b/atcodertools/fmtprediction/multi_case_layout.py
@@ -275,7 +275,7 @@ def _extract_single_block_indexed_layout(
     return prefix_text, case_text
 
 
-def _multi_case_evidence_context(
+def multi_case_evidence_context(
     content: ProblemContent,
 ) -> str:
     """
@@ -320,7 +320,7 @@ def _multi_case_evidence_context(
     )
 
 
-def _context_supports_count_variable(
+def context_supports_count_variable(
     context: str,
     variable_name: str,
 ) -> bool:
@@ -376,7 +376,7 @@ def _context_supports_count_variable(
     )
 
 
-def _candidate_layouts(
+def candidate_layouts(
     content: ProblemContent,
 ):
     blocks = content.get_input_format_blocks()

--- a/atcodertools/fmtprediction/predict_format.py
+++ b/atcodertools/fmtprediction/predict_format.py
@@ -12,9 +12,9 @@ from atcodertools.fmtprediction.models.format_prediction_result import (
 )
 from atcodertools.fmtprediction.models.type import Type
 from atcodertools.fmtprediction.multi_case_layout import (
-    _candidate_layouts,
-    _context_supports_count_variable,
-    _multi_case_evidence_context,
+    candidate_layouts,
+    context_supports_count_variable,
+    multi_case_evidence_context,
 )
 from atcodertools.fmtprediction.predict_simple_format import (
     SimpleFormatPredictionFailedError,
@@ -297,7 +297,7 @@ def predict_multi_case_format(
         raise NoMultiCaseFormatFoundError
 
     evidence_context = (
-        _multi_case_evidence_context(
+        multi_case_evidence_context(
             content
         )
     )
@@ -309,7 +309,7 @@ def predict_multi_case_format(
         prefix_text,
         case_text,
         structural_evidence,
-    ) in _candidate_layouts(content):
+    ) in candidate_layouts(content):
         prefix_candidates = _unique_formats(
             _predict_simple_format_candidates(
                 prefix_text
@@ -333,7 +333,7 @@ def predict_multi_case_format(
             ):
                 if (
                     not structural_evidence
-                    and not _context_supports_count_variable(
+                    and not context_supports_count_variable(
                         evidence_context,
                         case_count_var,
                     )


### PR DESCRIPTION
## 概要

#315 のフォローアップです。`predict_format.py` が `multi_case_layout` の `_` 付き関数を import していたため、モジュール間の正式な API として公開名に改名します。

- `_candidate_layouts` → `candidate_layouts`
- `_context_supports_count_variable` → `context_supports_count_variable`
- `_multi_case_evidence_context` → `multi_case_evidence_context`

挙動の変更はありません(改名のみ)。

## 検証

- `tests.test_fmtprediction`(corpus 2,279問)/ `tests.test_multi_case_*` / `tests.test_fmtprediction_modern_corpus` すべて PASS
- flake8 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
