### PR TITLE
3次元配列の入力形式推定とコード生成に対応

### DIFF
--- a/atcodertools/codegen/code_generators/universal_code_generator.py
+++ b/atcodertools/codegen/code_generators/universal_code_generator.py
@@ -9,6 +9,7 @@ from atcodertools.fmtprediction.models.format import (
     Pattern,
     RepeatedCaseFormat,
     SingularPattern,
+    ThreeDimensionalPattern,
     TwoDimensionalPattern,
 )
 from atcodertools.fmtprediction.models.type import Type
@@ -36,6 +37,10 @@ class UniversalCodeGenerator():
                 "j": "j",
             }
 
+        self.info.setdefault("index", {})
+        self.info["index"].setdefault("i", "i")
+        self.info["index"].setdefault("j", "j")
+        self.info["index"].setdefault("k", "k")
         self._prefix_format = format_
         self._solve_format = format_
         self._case_count_var = None
@@ -52,8 +57,16 @@ class UniversalCodeGenerator():
     def _get_length(self, index) -> str:
         return self._insert_space_around_operators(str(index.get_length()))
 
-    def _loop_header(self, var: Variable, for_second_index: bool):
-        if for_second_index:
+    def _loop_header(
+        self,
+        var: Variable,
+        for_second_index: bool,
+        for_third_index: bool = False,
+    ):
+        if for_third_index:
+            index = var.third_index
+            loop_var = self.info["index"]["k"]
+        elif for_second_index:
             index = var.second_index
             loop_var = self.info["index"]["j"]
         else:
@@ -62,7 +75,7 @@ class UniversalCodeGenerator():
 
         return self.info["loop"]["header"].format(
             loop_var=loop_var,
-            length=self._get_length(index)
+            length=self._get_length(index),
         )
 
     def _insert_space_around_operators(self, code: str):
@@ -234,32 +247,71 @@ class UniversalCodeGenerator():
     def _get_input_func(self, type_: Type) -> str:
         return self.info["input_func"][type_.value]
 
-    def _get_format_keywords(self, var: Variable) -> dict:
-        result = {"name": var.name, "type": self._convert_type(
-            var.type), "default": self._default_val(var.type)}
+    def _get_format_keywords(
+        self,
+        var: Variable,
+    ) -> dict:
+        result = {
+            "name": var.name,
+            "type": self._convert_type(var.type),
+            "default": self._default_val(var.type),
+        }
+
         if "input_func" in self.info:
-            result["input_func"] = self._get_input_func(var.type)
+            result["input_func"] = (
+                self._get_input_func(var.type)
+            )
+
         if var.dim_num() == 0:
             pass
         elif var.dim_num() == 1:
-            result["length"] = self._get_length(var.first_index)
+            result["length"] = self._get_length(
+                var.first_index
+            )
         elif var.dim_num() == 2:
-            result.update({"length_i": self._get_length(
-                var.first_index), "length_j": self._get_length(var.second_index)})
+            result.update(
+                {
+                    "length_i": self._get_length(
+                        var.first_index
+                    ),
+                    "length_j": self._get_length(
+                        var.second_index
+                    ),
+                }
+            )
+        elif var.dim_num() == 3:
+            result.update(
+                {
+                    "length_i": self._get_length(
+                        var.first_index
+                    ),
+                    "length_j": self._get_length(
+                        var.second_index
+                    ),
+                    "length_k": self._get_length(
+                        var.third_index
+                    ),
+                }
+            )
         else:
             raise NotImplementedError
-        # TODO: index_i, index_jは含めなくていいか？
+
         return result
 
-    def _get_variable_kind(self, var: Variable) -> str:
+    def _get_variable_kind(
+        self,
+        var: Variable,
+    ) -> str:
         if var.dim_num() == 0:
             return var.type.value
-        elif var.dim_num() == 1:
+        if var.dim_num() == 1:
             return "seq"
-        elif var.dim_num() == 2:
+        if var.dim_num() == 2:
             return "2d_seq"
-        else:
-            raise NotImplementedError
+        if var.dim_num() == 3:
+            return "3d_seq"
+
+        raise NotImplementedError
 
     def _get_argument(self, var: Variable):
         kwd = self._get_format_keywords(var)
@@ -340,14 +392,29 @@ class UniversalCodeGenerator():
 
     def _get_var_name(self, var: Variable):
         name = var.name
+
         if var.dim_num() == 0:
             return name
-        elif var.dim_num() == 1:
-            return self.info["access"]["seq"].format(name=name, index=self.info["index"]["i"])
-        elif var.dim_num() == 2:
-            return self.info["access"]["2d_seq"].format(name=name, index_i=self.info["index"]["i"], index_j=self.info["index"]["j"])
-        else:
-            raise NotImplementedError
+        if var.dim_num() == 1:
+            return self.info["access"]["seq"].format(
+                name=name,
+                index=self.info["index"]["i"],
+            )
+        if var.dim_num() == 2:
+            return self.info["access"]["2d_seq"].format(
+                name=name,
+                index_i=self.info["index"]["i"],
+                index_j=self.info["index"]["j"],
+            )
+        if var.dim_num() == 3:
+            return self.info["access"]["3d_seq"].format(
+                name=name,
+                index_i=self.info["index"]["i"],
+                index_j=self.info["index"]["j"],
+                index_k=self.info["index"]["k"],
+            )
+
+        raise NotImplementedError
 
     def _append(self, lines, s, indent=0):
         if s == "":
@@ -379,58 +446,229 @@ class UniversalCodeGenerator():
         self._append_declaration_and_allocation(lines, pattern, global_mode)
         self._append(lines, self._input_code_for_var(var))
 
-    def _render_pattern(self, pattern: Pattern, global_mode):
+    def _render_pattern(
+        self,
+        pattern: Pattern,
+        global_mode,
+    ):
         lines = []
+        representative_var = (
+            pattern.all_vars()[0]
+        )
 
-        representative_var = pattern.all_vars()[0]
         if isinstance(pattern, SingularPattern):
-            self._append_singular_pattern(lines, pattern, global_mode)
+            self._append_singular_pattern(
+                lines,
+                pattern,
+                global_mode,
+            )
+
         elif isinstance(pattern, ParallelPattern):
             added = False
+
             if len(pattern.all_vars()) == 1:
                 var = pattern.all_vars()[0]
                 kwd = self._get_format_keywords(var)
+
                 if global_mode:
                     op = "allocate_and_input"
                 else:
-                    op = "declare_and_allocate_and_input"
+                    op = (
+                        "declare_and_allocate_and_input"
+                    )
+
                 if op in self.info:
-                    self._append(lines, self.info[op]["seq"].format(**kwd))
+                    self._append(
+                        lines,
+                        self.info[op]["seq"].format(
+                            **kwd
+                        ),
+                    )
                     added = True
+
             if not added:
                 self._append_declaration_and_allocation(
-                    lines, pattern, global_mode)
-                self._append(lines, self._loop_header(
-                    representative_var, False))
+                    lines,
+                    pattern,
+                    global_mode,
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                    ),
+                )
+
                 for var in pattern.all_vars():
-                    self._append(lines, self._input_code_for_var(var), 1)
-                self._append(lines, self.info["loop"]["footer"].format())
-        elif isinstance(pattern, TwoDimensionalPattern):
+                    self._append(
+                        lines,
+                        self._input_code_for_var(var),
+                        1,
+                    )
+
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(),
+                )
+
+        elif isinstance(
+            pattern,
+            TwoDimensionalPattern,
+        ):
             added = False
+
             if len(pattern.all_vars()) == 1:
                 var = pattern.all_vars()[0]
                 kwd = self._get_format_keywords(var)
+
                 if global_mode:
                     op = "allocate_and_input"
                 else:
-                    op = "declare_and_allocate_and_input"
+                    op = (
+                        "declare_and_allocate_and_input"
+                    )
+
                 if op in self.info:
-                    self._append(lines, self.info[op]["2d_seq"].format(**kwd))
+                    self._append(
+                        lines,
+                        self.info[op]["2d_seq"].format(
+                            **kwd
+                        ),
+                    )
                     added = True
+
             if not added:
                 self._append_declaration_and_allocation(
-                    lines, pattern, global_mode)
+                    lines,
+                    pattern,
+                    global_mode,
+                )
                 self._append(
-                    lines, self._loop_header(representative_var, False))
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                    ),
+                )
                 self._append(
-                    lines, self._loop_header(representative_var, True), 1)
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        True,
+                    ),
+                    1,
+                )
+
                 for var in pattern.all_vars():
-                    self._append(lines, self._input_code_for_var(var), 2)
-                # loop_varを指定してるのはVisual Basicなどfooterにループの変数書かなきゃいけない言語向けのつもり
-                self._append(lines, self.info["loop"]["footer"].format(
-                    loop_var=self.info["index"]["j"]), 1)
-                self._append(lines, self.info["loop"]["footer"].format(
-                    loop_var=self.info["index"]["i"]))
+                    self._append(
+                        lines,
+                        self._input_code_for_var(var),
+                        2,
+                    )
+
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["j"]
+                    ),
+                    1,
+                )
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["i"]
+                    ),
+                )
+
+        elif isinstance(
+            pattern,
+            ThreeDimensionalPattern,
+        ):
+            added = False
+
+            if len(pattern.all_vars()) == 1:
+                var = pattern.all_vars()[0]
+                kwd = self._get_format_keywords(var)
+
+                if global_mode:
+                    op = "allocate_and_input"
+                else:
+                    op = (
+                        "declare_and_allocate_and_input"
+                    )
+
+                if (
+                    op in self.info
+                    and "3d_seq" in self.info[op]
+                ):
+                    self._append(
+                        lines,
+                        self.info[op]["3d_seq"].format(
+                            **kwd
+                        ),
+                    )
+                    added = True
+
+            if not added:
+                self._append_declaration_and_allocation(
+                    lines,
+                    pattern,
+                    global_mode,
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                    ),
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        True,
+                    ),
+                    1,
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                        True,
+                    ),
+                    2,
+                )
+
+                for var in pattern.all_vars():
+                    self._append(
+                        lines,
+                        self._input_code_for_var(var),
+                        3,
+                    )
+
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["k"]
+                    ),
+                    2,
+                )
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["j"]
+                    ),
+                    1,
+                )
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["i"]
+                    ),
+                )
+
         else:
             raise NotImplementedError
 

--- a/atcodertools/codegen/code_generators/universal_generator/python.toml
+++ b/atcodertools/codegen/code_generators/universal_generator/python.toml
@@ -10,6 +10,7 @@ i = "i"
 j = "j"
 
 # ループ
+k = "k"
 [loop]
 header = "for {loop_var} in range({length}):"
 footer = ""
@@ -35,16 +36,19 @@ seq = ""
 2d_seq = ""
 
 # 確保
+3d_seq = ""
 [allocate]
 seq = "{name} = [{default}] * ({length})"
 2d_seq = "{name} = [[{default}] * ({length_j}) for _ in {length_i}]"
 
 # 宣言と確保
+3d_seq = "{name} = [[[{default}] * ({length_k}) for _ in range({length_j})] for _ in range({length_i})]"
 [declare_and_allocate]
 seq = "{name} = [{default}] * ({length})  # type: \"List[{type}]\""
 self.declare_and_allocate_2d_seq = "{name} = [[{default}] * ({length_j}) for _ in {length_i}]  # type: \"List[List[{type}]]\""
 
 # 入力関数
+3d_seq = "{name} = [[[{default}] * ({length_k}) for _ in range({length_j})] for _ in range({length_i})] # type: \"List[List[List[{type}]]]\""
 [input_func]
 int = "int(next(tokens))"
 float = "float(next(tokens))"
@@ -68,11 +72,13 @@ seq = "{name} = [{input_func} for _ in range({length})]"
 2d_seq = "{name} = [[{input_func} for _ in range({length_j})] for _ in range({length_i})]"
 
 # 宣言と確保と入力
+3d_seq = "{name} = [[[{input_func} for _ in range({length_k})] for _ in range({length_j})] for _ in range({length_i})]"
 [declare_and_allocate_and_input]
 seq = "{name} = [{input_func} for _ in range({length})]  # type: \"List[{type}]\""
 2d_seq = "{name} = [[{input_func} for _ in range({length_j})] for _ in range({length_i})]  # type: \"List[List[{type}]]\""
 
 # 引数
+3d_seq = "{name} = [[[{input_func} for _ in range({length_k})] for _ in range({length_j})] for _ in range({length_i})] # type: \"List[List[List[{type}]]]\""
 [arg]
 int = "{name}: int"
 float = "{name}: float"
@@ -81,6 +87,8 @@ seq = "{name}: \"List[{type}]\""
 2d_seq = "{name}: \"List[List[{type}]]\""
 
 # 配列アクセス
+3d_seq = "{name}: \"List[List[List[{type}]]]\""
 [access]
 seq = "{name}[{index}]"
 2d_seq = "{name}[{index_i}][{index_j}]"
+3d_seq = "{name}[{index_i}][{index_j}][{index_k}]"

--- a/atcodertools/fmtprediction/models/format.py
+++ b/atcodertools/fmtprediction/models/format.py
@@ -114,6 +114,30 @@ class TwoDimensionalPattern(Pattern):
         return TwoDimensionalPattern(name_to_var[self.var.name])
 
 
+class ThreeDimensionalPattern(Pattern):
+    """A three-dimensional dense array."""
+
+    def __init__(self, var: T):
+        self.var = var
+
+    def __str__(self):
+        return (
+            "(ThreeDimensional: {})"
+            .format(self.var.name)
+        )
+
+    def all_vars(self):
+        return [self.var]
+
+    def with_replaced_vars(
+        self,
+        name_to_var: Dict[str, Variable],
+    ):
+        return ThreeDimensionalPattern(
+            name_to_var[self.var.name]
+        )
+
+
 class ParallelPattern(Pattern):
 
     """

--- a/atcodertools/fmtprediction/models/format_prediction_result.py
+++ b/atcodertools/fmtprediction/models/format_prediction_result.py
@@ -33,13 +33,16 @@ class FormatPredictionResult:
                 var.first_index,
                 var.second_index,
                 var_to_type[var.name],
+                third_index=var.third_index,
             )
 
         typed_format = Format()
 
         for pattern in simple_format.sequence:
             typed_format.push_back(
-                pattern.with_replaced_vars(var_to_info)
+                pattern.with_replaced_vars(
+                    var_to_info
+                )
             )
 
         return typed_format

--- a/atcodertools/fmtprediction/models/variable.py
+++ b/atcodertools/fmtprediction/models/variable.py
@@ -5,16 +5,21 @@ from atcodertools.fmtprediction.models.type import Type
 
 
 class SimpleVariable:
-
-    def __init__(self,
-                 name: str,
-                 first_index: Optional[Index],
-                 second_index: Optional[Index]):
+    def __init__(
+        self,
+        name: str,
+        first_index: Optional[Index],
+        second_index: Optional[Index],
+        third_index: Optional[Index] = None,
+    ):
         self.name = name
         self.first_index = first_index
         self.second_index = second_index
+        self.third_index = third_index
 
     def dim_num(self):
+        if self.third_index:
+            return 3
         if self.second_index:
             return 2
         if self.first_index:
@@ -23,29 +28,42 @@ class SimpleVariable:
 
     @classmethod
     def create(cls, name: str, dim_num: int):
-        assert dim_num <= 2
+        assert dim_num <= 3
 
         first_index = None
         second_index = None
+        third_index = None
 
+        if dim_num >= 3:
+            third_index = Index()
         if dim_num >= 2:
             second_index = Index()
         if dim_num >= 1:
             first_index = Index()
 
-        return SimpleVariable(name, first_index, second_index)
+        return SimpleVariable(
+            name,
+            first_index,
+            second_index,
+            third_index,
+        )
 
 
 class Variable(SimpleVariable):
+    """SimpleVariable + type information."""
 
-    """
-        SimpleVariable + type information
-    """
-
-    def __init__(self,
-                 name: str,
-                 first_index: Optional[Index],
-                 second_index: Optional[Index],
-                 type_: Type):
-        super().__init__(name, first_index, second_index)
+    def __init__(
+        self,
+        name: str,
+        first_index: Optional[Index],
+        second_index: Optional[Index],
+        type_: Type,
+        third_index: Optional[Index] = None,
+    ):
+        super().__init__(
+            name,
+            first_index,
+            second_index,
+            third_index,
+        )
         self.type = type_

--- a/atcodertools/fmtprediction/models/variable_token.py
+++ b/atcodertools/fmtprediction/models/variable_token.py
@@ -1,33 +1,46 @@
 import re
-from typing import Optional, List
+from typing import List, Optional
 
 
-VALID_VAR_NAME_REG_EXP = re.compile("[a-zA-Z_]+")
+VALID_VAR_NAME_REG_EXP = re.compile(
+    "[a-zA-Z_]+"
+)
 
 
 class VariableToken:
-
     """
-    This model is used on the tokenization stage to store variable information with all string indices
-    This class supports up to 2 dimensions.
+    Variable information used during format tokenization.
+
+    Up to three indices are supported.
     """
 
-    def __init__(self, var_name: str, first_index: Optional[str], second_index: Optional[str]):
-        def normalize(x: str):
-            if x is None:
+    def __init__(
+        self,
+        var_name: str,
+        first_index: Optional[str],
+        second_index: Optional[str],
+        third_index: Optional[str] = None,
+    ):
+        def normalize(value):
+            if value is None:
                 return None
-            return x.rstrip(",")
+            return value.rstrip(",")
 
-        def fixed_var_name(x: str):
-            if x[-1] == "_":
-                return x[:-1]
-            return x
+        def fixed_var_name(value):
+            if value.endswith("_"):
+                return value[:-1]
+            return value
 
-        self.var_name = fixed_var_name(normalize(var_name))
+        self.var_name = fixed_var_name(
+            normalize(var_name)
+        )
         self.first_index = normalize(first_index)
         self.second_index = normalize(second_index)
+        self.third_index = normalize(third_index)
 
     def dim_num(self):
+        if self.third_index:
+            return 3
         if self.second_index:
             return 2
         if self.first_index:
@@ -37,14 +50,24 @@ class VariableToken:
     def is_valid(self):
         if not self._has_valid_var_name():
             return False
-        if not self._is_valid_index(self.first_index):
-            return False
-        if not self._is_valid_index(self.second_index):
-            return False
+
+        for index in (
+            self.first_index,
+            self.second_index,
+            self.third_index,
+        ):
+            if not self._is_valid_index(index):
+                return False
+
         return True
 
     def _has_valid_var_name(self):
-        return VALID_VAR_NAME_REG_EXP.fullmatch(self.var_name) is not None
+        return (
+            VALID_VAR_NAME_REG_EXP.fullmatch(
+                self.var_name
+            )
+            is not None
+        )
 
     @staticmethod
     def _is_valid_index(index):
@@ -52,14 +75,19 @@ class VariableToken:
             return True
         if len(index) == 0:
             return False
-        if not index[-1].isalpha() and not index[-1].isdigit():
+        if (
+            not index[-1].isalpha()
+            and not index[-1].isdigit()
+        ):
             return False
-        if index.find(',') != -1:
+        if index.find(",") != -1:
             return False
         return True
 
 
 class TokenizedFormat:
-
-    def __init__(self, var_tokens: List[VariableToken]):
+    def __init__(
+        self,
+        var_tokens: List[VariableToken],
+    ):
         self.var_tokens = var_tokens

--- a/atcodertools/fmtprediction/predict_simple_format.py
+++ b/atcodertools/fmtprediction/predict_simple_format.py
@@ -4,7 +4,14 @@ from collections import OrderedDict
 
 from atcodertools.fmtprediction.models.variable import SimpleVariable
 from atcodertools.fmtprediction.models.variable_token import VariableToken
-from atcodertools.fmtprediction.models.format import SingularPattern, Format, ParallelPattern, TwoDimensionalPattern, WrongGroupingError
+from atcodertools.fmtprediction.models.format import (
+    Format,
+    ParallelPattern,
+    SingularPattern,
+    ThreeDimensionalPattern,
+    TwoDimensionalPattern,
+    WrongGroupingError,
+)
 
 
 class UnknownPeriodError(Exception):
@@ -26,33 +33,51 @@ def _predict_period(seq: List[int]):
         return 1
 
 
-def _predict_simple_format_main(var_tokens: List[VariableToken], to_1d_flag=False) -> Format[SimpleVariable]:
+def _predict_simple_format_main(
+    var_tokens: List[VariableToken],
+    to_1d_flag=False,
+) -> Format[SimpleVariable]:
     var_to_positions = {}
     var_to_simple_var = OrderedDict()
 
-    # Pre-computation of the min / max value of each of the first and second
-    # indices.
     for pos, var_token in enumerate(var_tokens):
         var_name = var_token.var_name
 
         if var_name not in var_to_simple_var:
-            var_to_simple_var[var_name] = SimpleVariable.create(
-                var_name, var_token.dim_num())
+            var_to_simple_var[var_name] = (
+                SimpleVariable.create(
+                    var_name,
+                    var_token.dim_num(),
+                )
+            )
             var_to_positions[var_name] = []
 
         var_to_positions[var_name].append(pos)
 
+        if var_token.dim_num() >= 3:
+            var_to_simple_var[
+                var_name
+            ].third_index.update(
+                var_token.third_index
+            )
+
         if var_token.dim_num() >= 2:
-            var_to_simple_var[var_name].second_index.update(
-                var_token.second_index)
+            var_to_simple_var[
+                var_name
+            ].second_index.update(
+                var_token.second_index
+            )
+
         if var_token.dim_num() >= 1:
-            var_to_simple_var[var_name].first_index.update(
-                var_token.first_index)
+            var_to_simple_var[
+                var_name
+            ].first_index.update(
+                var_token.first_index
+            )
 
-    # Building format nodes
     already_processed_vars = set()
+    root = Format()
 
-    root = Format()  # type: Format[SimpleVariable]
     for pos, var_token in enumerate(var_tokens):
         var_name = var_token.var_name
         simple_var = var_to_simple_var[var_name]
@@ -63,32 +88,66 @@ def _predict_simple_format_main(var_tokens: List[VariableToken], to_1d_flag=Fals
         dim = var_token.dim_num()
 
         if dim == 2 and to_1d_flag:
-            simple_var.first_index = simple_var.second_index
+            simple_var.first_index = (
+                simple_var.second_index
+            )
             simple_var.second_index = None
             dim = 1
 
         if dim == 0:
-            root.push_back(SingularPattern(simple_var))
+            root.push_back(
+                SingularPattern(simple_var)
+            )
             already_processed_vars.add(var_name)
+
         elif dim == 1:
-            period = _predict_period(var_to_positions[var_name])
-            parallel_vars_group = [var_to_simple_var[token.var_name]
-                                   for token in var_tokens[pos:pos + period]]
-            try:
-                root.push_back(ParallelPattern(parallel_vars_group))
-            except WrongGroupingError:
-                raise
+            period = _predict_period(
+                var_to_positions[var_name]
+            )
+            parallel_vars_group = [
+                var_to_simple_var[token.var_name]
+                for token in var_tokens[
+                    pos:pos + period
+                ]
+            ]
+
+            root.push_back(
+                ParallelPattern(
+                    parallel_vars_group
+                )
+            )
+
             for var in parallel_vars_group:
-                already_processed_vars.add(var.name)
+                already_processed_vars.add(
+                    var.name
+                )
+
         elif dim == 2:
-            root.push_back(TwoDimensionalPattern(simple_var))
+            root.push_back(
+                TwoDimensionalPattern(
+                    simple_var
+                )
+            )
+            already_processed_vars.add(var_name)
+
+        elif dim == 3:
+            root.push_back(
+                ThreeDimensionalPattern(
+                    simple_var
+                )
+            )
+            already_processed_vars.add(var_name)
+
         else:
             raise NotImplementedError
-        already_processed_vars.add(var_name)
+
     return root
 
 
-def predict_simple_format(var_tokens: List[VariableToken], to_1d_flag=False) -> Format[SimpleVariable]:
+def predict_simple_format(
+    var_tokens: List[VariableToken],
+    to_1d_flag=False,
+) -> Format[SimpleVariable]:
     try:
         return _predict_simple_format_main(var_tokens, to_1d_flag)
     except (WrongGroupingError, UnknownPeriodError):

--- a/atcodertools/fmtprediction/predict_simple_format.py
+++ b/atcodertools/fmtprediction/predict_simple_format.py
@@ -94,6 +94,13 @@ def _predict_simple_format_main(
             simple_var.second_index = None
             dim = 1
 
+        elif dim == 3 and to_1d_flag:
+            # A compact character row represents the innermost
+            # dimension as one string token. Preserve the outer two
+            # indices and collapse only the third dimension.
+            simple_var.third_index = None
+            dim = 2
+
         if dim == 0:
             root.push_back(
                 SingularPattern(simple_var)

--- a/atcodertools/fmtprediction/predict_types.py
+++ b/atcodertools/fmtprediction/predict_types.py
@@ -6,8 +6,13 @@ from atcodertools.fmtprediction.models.type import Type
 from atcodertools.client.models.sample import Sample
 from atcodertools.fmtprediction.models.variable import SimpleVariable
 from atcodertools.fmtprediction.models.index import Index
-from atcodertools.fmtprediction.models.format import Format, SingularPattern, TwoDimensionalPattern, \
-    ParallelPattern
+from atcodertools.fmtprediction.models.format import (
+    Format,
+    ParallelPattern,
+    SingularPattern,
+    ThreeDimensionalPattern,
+    TwoDimensionalPattern,
+)
 from atcodertools.fmtprediction.token_manager import TokenManager
 
 
@@ -139,16 +144,61 @@ class TypePredictor:
 
     def _fetch_generator(self):
         for pattern in self._fmt.sequence:
-            if isinstance(pattern, SingularPattern):
+            if isinstance(
+                pattern,
+                SingularPattern,
+            ):
                 yield pattern.var
-            elif isinstance(pattern, TwoDimensionalPattern):
-                for _ in range(self._loop_size(pattern.var.first_index)):
-                    for _ in range(self._loop_size(pattern.var.second_index)):
+
+            elif isinstance(
+                pattern,
+                TwoDimensionalPattern,
+            ):
+                for _ in range(
+                    self._loop_size(
+                        pattern.var.first_index
+                    )
+                ):
+                    for _ in range(
+                        self._loop_size(
+                            pattern.var.second_index
+                        )
+                    ):
                         yield pattern.var
-            elif isinstance(pattern, ParallelPattern):
-                for _ in range(self._loop_size(pattern.loop_index)):
-                    for v in pattern.vars:
-                        yield v
+
+            elif isinstance(
+                pattern,
+                ThreeDimensionalPattern,
+            ):
+                for _ in range(
+                    self._loop_size(
+                        pattern.var.first_index
+                    )
+                ):
+                    for _ in range(
+                        self._loop_size(
+                            pattern.var.second_index
+                        )
+                    ):
+                        for _ in range(
+                            self._loop_size(
+                                pattern.var.third_index
+                            )
+                        ):
+                            yield pattern.var
+
+            elif isinstance(
+                pattern,
+                ParallelPattern,
+            ):
+                for _ in range(
+                    self._loop_size(
+                        pattern.loop_index
+                    )
+                ):
+                    for var in pattern.vars:
+                        yield var
+
         yield None
         raise TooManyFetchesError()
 
@@ -162,7 +212,10 @@ def merge_type_dicts(to_dict: Dict[str, Type], src_dict: Dict[str, Type]):
     return to_dict
 
 
-def predict_types(simple_format: Format[SimpleVariable], samples: List[Sample]) -> Dict[str, Type]:
+def predict_types(
+    simple_format: Format[SimpleVariable],
+    samples: List[Sample],
+) -> Dict[str, Type]:
     res_type_dict = {}
     for sample in samples:
         token_manager = TokenManager(sample.get_input().split())
@@ -175,8 +228,13 @@ def predict_types(simple_format: Format[SimpleVariable], samples: List[Sample]) 
                 res_type_dict,
                 predictor.get_typing_result())
         except (
-                TooLessFetchesError, TooManyFetchesError, KeyError, InvalidLoopSizeError,
-                InvalidLoopIndexError, EvaluateError):
+                TooLessFetchesError,
+                TooManyFetchesError,
+                KeyError,
+                InvalidLoopSizeError,
+                InvalidLoopIndexError,
+                EvaluateError,
+        ):
             raise TypePredictionFailedError
 
     return res_type_dict

--- a/atcodertools/fmtprediction/tokenize_format.py
+++ b/atcodertools/fmtprediction/tokenize_format.py
@@ -1,8 +1,15 @@
 import copy
+from itertools import combinations
 from typing import List, Dict
 
-from atcodertools.fmtprediction.models.calculator import CalcNode, CalcParseError
-from atcodertools.fmtprediction.models.variable_token import VariableToken, TokenizedFormat
+from atcodertools.fmtprediction.models.calculator import (
+    CalcNode,
+    CalcParseError,
+)
+from atcodertools.fmtprediction.models.variable_token import (
+    VariableToken,
+    TokenizedFormat,
+)
 
 from atcodertools.fmtprediction.token_manager import TokenManager
 
@@ -66,8 +73,16 @@ def _remove_spaces_in_curly_brackets(input_format):
 
 
 def _sanitized_tokens(input_format: str) -> List[str]:
-    input_format = input_format.replace("\n", " ").replace("…", " ").replace("...", " ").replace(
-        "..", " ").replace("\\ ", " ").replace("}", "} ").replace("　", " ").replace(", ", ",")
+    input_format = (
+        input_format.replace("\n", " ")
+        .replace("…", " ")
+        .replace("...", " ")
+        .replace("..", " ")
+        .replace("\\ ", " ")
+        .replace("}", "} ")
+        .replace("　", " ")
+        .replace(", ", ",")
+    )
     input_format = _remove_spaces_in_curly_brackets(input_format)
     input_format = _divide_consecutive_vars(input_format)
     input_format = _normalize_index(input_format)
@@ -102,7 +117,10 @@ class FormatSearcher:
             self._answers.append(TokenizedFormat(copy.deepcopy(var_token_seq)))
             return
 
-        for var_token in self._possible_var_tokens(self._token_manager.peek(), var_to_dim_num):
+        for var_token in self._possible_var_tokens(
+            self._token_manager.peek(),
+            var_to_dim_num,
+        ):
             next_var_to_dim_num = copy.deepcopy(var_to_dim_num)
             next_var_to_dim_num[var_token.var_name] = var_token.dim_num()
             try:
@@ -114,48 +132,143 @@ class FormatSearcher:
                 var_token_seq.pop()
 
     @staticmethod
-    def _possible_var_tokens(token: str, current_var_to_dim_num: Dict[str, int]) -> List[VariableToken]:
+    def _possible_var_tokens(
+        token: str,
+        current_var_to_dim_num: Dict[str, int],
+    ) -> List[VariableToken]:
         """
-        Only considers to divide the given token into at most 3 pieces (that is, to assume at most 2 dimensional indexes).
-        :param token: e.g. "N", "abc_1_2" or "a_1 ... a_N"
-        :param current_var_to_dim_num: utilized to detect unknown variables (for pruning purpose)
-        """
-        var_token_candidates = [VariableToken(token, None, None)]
-        var_token_candidates += [VariableToken(
-            token[:i],
-            token[i:],
-            None) for i in range(1, len(token))]
-        for i in range(1, len(token)):
-            for j in range(i + 1, len(token)):
-                var_token_candidates += [
-                    VariableToken(token[:i], token[i:j], token[j:])]
+        Divide a token into a variable name and up to
+        three index expressions.
 
-        def check_if_possible(var_token: VariableToken):
-            # check syntax error
+        Examples include ``N``, ``a_1``,
+        ``a_1,2`` and ``a_1,2,3``.
+        """
+        candidates = [
+            VariableToken(
+                token,
+                None,
+                None,
+                None,
+            )
+        ]
+
+        for first_split in range(
+            1,
+            len(token),
+        ):
+            candidates.append(
+                VariableToken(
+                    token[:first_split],
+                    token[first_split:],
+                    None,
+                    None,
+                )
+            )
+
+        for first_split in range(
+            1,
+            len(token),
+        ):
+            for second_split in range(
+                first_split + 1,
+                len(token),
+            ):
+                candidates.append(
+                    VariableToken(
+                        token[:first_split],
+                        token[
+                            first_split:second_split
+                        ],
+                        token[second_split:],
+                        None,
+                    )
+                )
+
+        three_dimensional_splits = sorted(
+            {
+                boundary
+                for position, character in enumerate(
+                    token
+                )
+                if character in ("_", ",")
+                for boundary in (
+                    position,
+                    position + 1,
+                )
+                if 0 < boundary < len(token)
+            }
+        )
+
+        for (
+            first_split,
+            second_split,
+            third_split,
+        ) in combinations(
+            three_dimensional_splits,
+            3,
+        ):
+            candidates.append(
+                VariableToken(
+                    token[:first_split],
+                    token[
+                        first_split:second_split
+                    ],
+                    token[
+                        second_split:third_split
+                    ],
+                    token[third_split:],
+                )
+            )
+
+        def check_if_possible(var_token):
             if not var_token.is_valid():
                 return False
 
-            # check kind of synonym error using current_var_to_dim_num
-            for index in [var_token.first_index, var_token.second_index]:
+            for index in (
+                var_token.first_index,
+                var_token.second_index,
+                var_token.third_index,
+            ):
                 if index is None:
                     continue
 
                 try:
-                    for sub_var in CalcNode.parse(index).get_all_variables():
-                        if sub_var not in current_var_to_dim_num:
-                            return False
+                    variables = (
+                        CalcNode.parse(index)
+                        .get_all_variables()
+                    )
                 except CalcParseError:
                     return False
 
-            if var_token.var_name in current_var_to_dim_num \
-                    and current_var_to_dim_num[var_token.var_name] != var_token.dim_num():
+                for sub_var in variables:
+                    if (
+                        sub_var
+                        not in current_var_to_dim_num
+                    ):
+                        return False
+
+            if (
+                var_token.var_name
+                in current_var_to_dim_num
+                and current_var_to_dim_num[
+                    var_token.var_name
+                ]
+                != var_token.dim_num()
+            ):
                 return False
+
             return True
 
-        return [var_token for var_token in var_token_candidates if check_if_possible(var_token)]
+        return [
+            candidate
+            for candidate in candidates
+            if check_if_possible(candidate)
+        ]
 
 
-def search_formats_with_minimum_vars(input_format: str) -> List[TokenizedFormat]:
+def search_formats_with_minimum_vars(
+    input_format: str,
+) -> List[TokenizedFormat]:
     """
     Fast enough for realistic instances.
     This method returns possible formats with the smallest number of variables.

--- a/tests/resources/test_fmtprediction/answer.txt
+++ b/tests/resources/test_fmtprediction/answer.txt
@@ -1325,7 +1325,7 @@ code-festival-2015-morning-middle-C      OK                   [(Singular: N),(Pa
 code-festival-2015-morning-middle-D      OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 code-festival-2015-okinawa-open-A        OK                   [(Singular: H),(Singular: W),(Singular: K)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>)]
 code-festival-2015-okinawa-open-B        OK                   [(Singular: N),(Singular: X),(Singular: Y),(Parallel: a,b | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
-code-festival-2015-okinawa-open-C        No result
+code-festival-2015-okinawa-open-C        OK                   [(Singular: N),(TwoDimensional: c)] [('N', <class 'int'>), ('c', <class 'str'>)]
 code-festival-2015-okinawa-open-D        OK                   [(Singular: N),(Singular: M),(Parallel: p,q | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('p', <class 'int'>), ('q', <class 'int'>)]
 code-festival-2015-okinawa-open-E        OK                   [(Singular: H),(Singular: W)] [('H', <class 'int'>), ('W', <class 'int'>)]
 code-festival-2015-okinawa-open-F        OK                   [(Singular: N),(Parallel: x,y | 1 to N),(Singular: x_a),(Singular: y_a),(Singular: x_b),(Singular: y_b),(Singular: x_c),(Singular: y_c)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('x_a', <class 'int'>), ('y_a', <class 'int'>), ('x_b', <class 'int'>), ('y_b', <class 'int'>), ('x_c', <class 'int'>), ('y_c', <class 'int'>)]

--- a/tests/resources/test_fmtprediction/answer.txt
+++ b/tests/resources/test_fmtprediction/answer.txt
@@ -330,7 +330,7 @@ abc079-C                                 OK                   [(Singular: ABCD)]
 abc079-D                                 OK                   [(Singular: H),(Singular: W),(TwoDimensional: c),(TwoDimensional: A)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'int'>), ('A', <class 'int'>)]
 abc080-A                                 OK                   [(Singular: N),(Singular: A),(Singular: B)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc080-B                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
-abc080-C                                 No result
+abc080-C                                 OK                   [(Singular: N),(ThreeDimensional: F),(TwoDimensional: P)] [('N', <class 'int'>), ('F', <class 'int'>), ('P', <class 'int'>)]
 abc080-D                                 OK                   [(Singular: N),(Singular: C),(Parallel: s,t,c | 1 to N)] [('N', <class 'int'>), ('C', <class 'int'>), ('s', <class 'int'>), ('t', <class 'int'>), ('c', <class 'int'>)]
 abc081-A                                 No result
 abc081-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]

--- a/tests/resources/test_three_dimensional/official_cases.json
+++ b/tests/resources/test_three_dimensional/official_cases.json
@@ -1,0 +1,96 @@
+{
+  "schema": "atcoder_tools_three_dimensional_official_cases_v1",
+  "cases": [
+    {
+      "task_id": "abc080_c",
+      "source_url": "https://atcoder.jp/contests/abc080/tasks/abc080_c",
+      "source_html_sha256": "5549587fb76e4b228e9c022b05fa3e1478efabc53f47e42667a46fb337b9b735",
+      "input_format_text": "N\n\n\nF_{1,1,1}\n \nF_{1,1,2}\n \n...\n \nF_{1,5,1}\n \nF_{1,5,2}\n\n\n:\n\n\nF_{N,1,1}\n \nF_{N,1,2}\n \n...\n \nF_{N,5,1}\n \nF_{N,5,2}\n\n\nP_{1,0}\n \n...\n \nP_{1,10}\n\n\n:\n\n\nP_{N,0}\n \n...\n \nP_{N,10}",
+      "input_format_blocks": [
+        "N\n\n\nF_{1,1,1}\n \nF_{1,1,2}\n \n...\n \nF_{1,5,1}\n \nF_{1,5,2}\n\n\n:\n\n\nF_{N,1,1}\n \nF_{N,1,2}\n \n...\n \nF_{N,5,1}\n \nF_{N,5,2}\n\n\nP_{1,0}\n \n...\n \nP_{1,10}\n\n\n:\n\n\nP_{N,0}\n \n...\n \nP_{N,10}"
+      ],
+      "input_format_context_text": "入力\n入力は以下の形式で標準入力から与えられる。\nN\nF_{1,1,1}\nF_{1,1,2}\n...\nF_{1,5,1}\nF_{1,5,2}\n:\nF_{N,1,1}\nF_{N,1,2}\n...\nF_{N,5,1}\nF_{N,5,2}\nP_{1,0}\n...\nP_{1,10}\n:\nP_{N,0}\n...\nP_{N,10}",
+      "sample_inputs": [
+        "1\n1 1 0 1 0 0 0 1 0 1\n3 4 5 6 7 8 9 -2 -3 4 -2",
+        "2\n1 1 1 1 1 0 0 0 0 0\n0 0 0 0 0 1 1 1 1 1\n0 -2 -2 -2 -2 -2 -1 -1 -1 -1 -1\n0 -2 -2 -2 -2 -2 -1 -1 -1 -1 -1",
+        "3\n1 1 1 1 1 1 0 0 1 1\n0 1 0 1 1 1 1 0 1 0\n1 0 1 1 0 1 0 1 0 1\n-8 6 -2 -8 -8 4 8 7 -6 2 2\n-9 2 0 1 7 -5 0 -2 -6 5 5\n6 -6 7 -9 6 -5 8 0 -9 -7 -7"
+      ],
+      "expected_patterns": {
+        "F": "ThreeDimensionalPattern",
+        "P": "TwoDimensionalPattern"
+      },
+      "expected_variables": {
+        "N": {
+          "type": "Type.int",
+          "dim_num": 0
+        },
+        "F": {
+          "type": "Type.int",
+          "dim_num": 3
+        },
+        "P": {
+          "type": "Type.int",
+          "dim_num": 2
+        }
+      }
+    },
+    {
+      "task_id": "abc322_d",
+      "source_url": "https://atcoder.jp/contests/abc322/tasks/abc322_d",
+      "source_html_sha256": "b035bdb077eb9e3ac132aa7065bfa552437aa0abae017804872fdd79e5c8fe02",
+      "input_format_text": "P_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}\n\n\nP_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}\n\n\nP_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}\n\n\nP_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}\n\n\nP_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}\n\n\nP_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}\n\n\nP_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}\n\n\nP_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}\n\n\nP_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}\n\n\nP_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}\n\n\nP_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}\n\n\nP_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}",
+      "input_format_blocks": [
+        "P_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}\n\n\nP_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}\n\n\nP_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}\n\n\nP_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}\n\n\nP_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}\n\n\nP_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}\n\n\nP_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}\n\n\nP_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}\n\n\nP_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}\n\n\nP_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}\n\n\nP_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}\n\n\nP_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}"
+      ],
+      "input_format_context_text": "入力\n入力は以下の形式で標準入力から与えられる。\nP_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}\nP_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}\nP_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}\nP_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}\nP_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}\nP_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}\nP_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}\nP_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}\nP_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}\nP_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}\nP_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}\nP_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}",
+      "sample_inputs": [
+        "....\n###.\n.#..\n....\n....\n.###\n.##.\n....\n..#.\n.##.\n.##.\n.##.",
+        "###.\n#.#.\n##..\n....\n....\n..#.\n....\n....\n####\n##..\n#...\n#...",
+        "##..\n#..#\n####\n....\n....\n##..\n.##.\n....\n.#..\n.#..\n.#..\n.#..",
+        "....\n..#.\n....\n....\n....\n..#.\n....\n....\n....\n..#.\n....\n....",
+        "....\n####\n#...\n#...\n....\n####\n...#\n..##\n....\n..##\n..#.\n..##",
+        "###.\n.##.\n..#.\n.###\n....\n...#\n..##\n...#\n....\n#...\n#...\n#..."
+      ],
+      "expected_patterns": {
+        "P": "TwoDimensionalPattern"
+      },
+      "expected_variables": {
+        "P": {
+          "type": "Type.str",
+          "dim_num": 2
+        }
+      }
+    },
+    {
+      "task_id": "abc366_d",
+      "source_url": "https://atcoder.jp/contests/abc366/tasks/abc366_d",
+      "source_html_sha256": "0d97770abeb4742a6b0ca038a93622d982ba42e9cd90cca521f4c67d3cd732bc",
+      "input_format_text": "N\n\n\nA_{1,1,1}\n \nA_{1,1,2}\n \n\\ldots\n \nA_{1,1,N}\n\n\nA_{1,2,1}\n \nA_{1,2,2}\n \n\\ldots\n \nA_{1,2,N}\n\n\n\\vdots\n\n\nA_{1,N,1}\n \nA_{1,N,2}\n \n\\ldots\n \nA_{1,N,N}\n\n\nA_{2,1,1}\n \nA_{2,1,2}\n \n\\ldots\n \nA_{2,1,N}\n\n\nA_{2,2,1}\n \nA_{2,2,2}\n \n\\ldots\n \nA_{2,2,N}\n\n\n\\vdots\n\n\nA_{2,N,1}\n \nA_{2,N,2}\n \n\\ldots\n \nA_{2,N,N}\n\n\n\\vdots\n\n\nA_{N,1,1}\n \nA_{N,1,2}\n \n\\ldots\n \nA_{N,1,N}\n\n\nA_{N,2,1}\n \nA_{N,2,2}\n \n\\ldots\n \nA_{N,2,N}\n\n\n\\vdots\n\n\nA_{N,N,1}\n \nA_{N,N,2}\n \n\\ldots\n \nA_{N,N,N}\n\n\nQ\n\n\nLx_1\n \nRx_1\n \nLy_1\n \nRy_1\n \nLz_1\n \nRz_1\n\n\nLx_2\n \nRx_2\n \nLy_2\n \nRy_2\n \nLz_2\n \nRz_2\n\n\n\\vdots\n\n\nLx_Q\n \nRx_Q\n \nLy_Q\n \nRy_Q\n \nLz_Q\n \nRz_Q",
+      "input_format_blocks": [
+        "N\n\n\nA_{1,1,1}\n \nA_{1,1,2}\n \n\\ldots\n \nA_{1,1,N}\n\n\nA_{1,2,1}\n \nA_{1,2,2}\n \n\\ldots\n \nA_{1,2,N}\n\n\n\\vdots\n\n\nA_{1,N,1}\n \nA_{1,N,2}\n \n\\ldots\n \nA_{1,N,N}\n\n\nA_{2,1,1}\n \nA_{2,1,2}\n \n\\ldots\n \nA_{2,1,N}\n\n\nA_{2,2,1}\n \nA_{2,2,2}\n \n\\ldots\n \nA_{2,2,N}\n\n\n\\vdots\n\n\nA_{2,N,1}\n \nA_{2,N,2}\n \n\\ldots\n \nA_{2,N,N}\n\n\n\\vdots\n\n\nA_{N,1,1}\n \nA_{N,1,2}\n \n\\ldots\n \nA_{N,1,N}\n\n\nA_{N,2,1}\n \nA_{N,2,2}\n \n\\ldots\n \nA_{N,2,N}\n\n\n\\vdots\n\n\nA_{N,N,1}\n \nA_{N,N,2}\n \n\\ldots\n \nA_{N,N,N}\n\n\nQ\n\n\nLx_1\n \nRx_1\n \nLy_1\n \nRy_1\n \nLz_1\n \nRz_1\n\n\nLx_2\n \nRx_2\n \nLy_2\n \nRy_2\n \nLz_2\n \nRz_2\n\n\n\\vdots\n\n\nLx_Q\n \nRx_Q\n \nLy_Q\n \nRy_Q\n \nLz_Q\n \nRz_Q"
+      ],
+      "input_format_context_text": "入力\n入力は以下の形式で標準入力から与えられる。\nN\nA_{1,1,1}\nA_{1,1,2}\n\\ldots\nA_{1,1,N}\nA_{1,2,1}\nA_{1,2,2}\n\\ldots\nA_{1,2,N}\n\\vdots\nA_{1,N,1}\nA_{1,N,2}\n\\ldots\nA_{1,N,N}\nA_{2,1,1}\nA_{2,1,2}\n\\ldots\nA_{2,1,N}\nA_{2,2,1}\nA_{2,2,2}\n\\ldots\nA_{2,2,N}\n\\vdots\nA_{2,N,1}\nA_{2,N,2}\n\\ldots\nA_{2,N,N}\n\\vdots\nA_{N,1,1}\nA_{N,1,2}\n\\ldots\nA_{N,1,N}\nA_{N,2,1}\nA_{N,2,2}\n\\ldots\nA_{N,2,N}\n\\vdots\nA_{N,N,1}\nA_{N,N,2}\n\\ldots\nA_{N,N,N}\nQ\nLx_1\nRx_1\nLy_1\nRy_1\nLz_1\nRz_1\nLx_2\nRx_2\nLy_2\nRy_2\nLz_2\nRz_2\n\\vdots\nLx_Q\nRx_Q\nLy_Q\nRy_Q\nLz_Q\nRz_Q",
+      "sample_inputs": [
+        "2\n1 2\n3 4\n5 6\n7 8\n2\n1 2 2 2 1 1\n2 2 1 2 1 2",
+        "3\n733 857 714\n956 208 257\n123 719 648\n840 881 245\n245 112 746\n306 942 694\n58 870 849\n13 208 789\n687 906 783\n8\n3 3 3 3 1 1\n1 3 2 3 3 3\n2 2 2 3 1 1\n1 3 1 1 1 1\n2 3 2 3 2 3\n1 2 1 1 1 2\n3 3 2 2 1 3\n1 2 2 3 2 3"
+      ],
+      "expected_patterns": {
+        "A": "ThreeDimensionalPattern"
+      },
+      "expected_variables": {
+        "N": {
+          "type": "Type.int",
+          "dim_num": 0
+        },
+        "A": {
+          "type": "Type.int",
+          "dim_num": 3
+        },
+        "Q": {
+          "type": "Type.int",
+          "dim_num": 0
+        }
+      }
+    }
+  ]
+}

--- a/tests/resources/test_three_dimensional/official_cases.json
+++ b/tests/resources/test_three_dimensional/official_cases.json
@@ -91,6 +91,37 @@
           "dim_num": 0
         }
       }
+    },
+    {
+      "task_id": "code_festival_2015_okinawa_c",
+      "legacy_case_ids": [
+        "code-festival-2015-okinawa-open-C"
+      ],
+      "source_url": "https://atcoder.jp/contests/code-festival-2015-okinawa-open/tasks/code_festival_2015_okinawa_c",
+      "source_html_sha256": "e4aeb4096aaba6e46a0333100e90c42458256ee37a5a6c7a4ab9a5c9604fc8b0",
+      "input_format_text": "N\nc_{1, 1, 1}c_{1, 1, 2}c_{1, 1, 3}\nc_{1, 2, 1}c_{1, 2, 2}c_{1, 2, 3}\nc_{1, 3, 1}c_{1, 3, 2}c_{1, 3, 3}\nc_{2, 1, 1}c_{2, 1, 2}c_{2, 1, 3}\nc_{2, 2, 1}c_{2, 2, 2}c_{2, 2, 3}\nc_{2, 3, 1}c_{2, 3, 2}c_{2, 3, 3}\n:\nc_{N, 1, 1}c_{N, 1, 2}c_{N, 1, 3}\nc_{N, 2, 1}c_{N, 2, 2}c_{N, 2, 3}\nc_{N, 3, 1}c_{N, 3, 2}c_{N, 3, 3}\n",
+      "input_format_blocks": [
+        "N\nc_{1, 1, 1}c_{1, 1, 2}c_{1, 1, 3}\nc_{1, 2, 1}c_{1, 2, 2}c_{1, 2, 3}\nc_{1, 3, 1}c_{1, 3, 2}c_{1, 3, 3}\nc_{2, 1, 1}c_{2, 1, 2}c_{2, 1, 3}\nc_{2, 2, 1}c_{2, 2, 2}c_{2, 2, 3}\nc_{2, 3, 1}c_{2, 3, 2}c_{2, 3, 3}\n:\nc_{N, 1, 1}c_{N, 1, 2}c_{N, 1, 3}\nc_{N, 2, 1}c_{N, 2, 2}c_{N, 2, 3}\nc_{N, 3, 1}c_{N, 3, 2}c_{N, 3, 3}\n"
+      ],
+      "input_format_context_text": "",
+      "sample_inputs": [
+        "2\n#.#\n#.#\n#.#\n###\n###\n...\n",
+        "4\n###\n###\n###\n...\n###\n###\n##.\n##.\n##.\n###\n###\n###\n",
+        "4\n###\n###\n###\n...\n###\n###\n.#.\n.#.\n.#.\n###\n###\n###\n"
+      ],
+      "expected_patterns": {
+        "c": "TwoDimensionalPattern"
+      },
+      "expected_variables": {
+        "N": {
+          "type": "Type.int",
+          "dim_num": 0
+        },
+        "c": {
+          "type": "Type.str",
+          "dim_num": 2
+        }
+      }
     }
   ]
 }

--- a/tests/test_three_dimensional_codegen.py
+++ b/tests/test_three_dimensional_codegen.py
@@ -1,0 +1,225 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from atcodertools.codegen.code_generators.universal_code_generator import (
+    UniversalCodeGenerator,
+    get_builtin_code_generator_info_toml_path,
+)
+from atcodertools.codegen.code_style_config import CodeStyleConfig
+from atcodertools.codegen.models.code_gen_args import CodeGenArgs
+from atcodertools.common.language import PYTHON
+from atcodertools.constprediction.models.problem_constant_set import (
+    ProblemConstantSet,
+)
+from atcodertools.fmtprediction.models.format import (
+    Format,
+    SingularPattern,
+    ThreeDimensionalPattern,
+)
+from atcodertools.fmtprediction.models.index import Index
+from atcodertools.fmtprediction.models.type import Type
+from atcodertools.fmtprediction.models.variable import Variable
+
+
+def make_index(maximum):
+    index = Index()
+    index.update("1")
+    index.update(maximum)
+    return index
+
+
+def make_three_dimensional_format():
+    format_ = Format()
+
+    for name in ("D", "H", "W"):
+        format_.push_back(
+            SingularPattern(
+                Variable(
+                    name,
+                    None,
+                    None,
+                    Type.int,
+                )
+            )
+        )
+
+    array = Variable(
+        "A",
+        make_index("D"),
+        make_index("H"),
+        Type.int,
+        third_index=make_index("W"),
+    )
+
+    format_.push_back(
+        ThreeDimensionalPattern(array)
+    )
+
+    return format_
+
+
+class TestThreeDimensionalCodeGenerator(unittest.TestCase):
+    def setUp(self):
+        self.format = make_three_dimensional_format()
+        self.config = CodeStyleConfig(
+            lang=PYTHON.name
+        )
+        self.toml_path = (
+            get_builtin_code_generator_info_toml_path(
+                PYTHON.name
+            )
+        )
+
+    def generate_parameters(self):
+        generator = UniversalCodeGenerator(
+            self.format,
+            self.config,
+            self.toml_path,
+        )
+
+        return generator.generate_parameters()
+
+    def test_three_dimensional_parameters(self):
+        parameters = self.generate_parameters()
+
+        self.assertEqual(
+            "D, H, W, A",
+            parameters["actual_arguments"],
+        )
+        self.assertIn(
+            'A: "List[List[List[int]]]"',
+            parameters["formal_arguments"],
+        )
+
+        combined = parameters[
+            "input_part_with_solve_function"
+        ]
+
+        self.assertIn(
+            "range(D)",
+            combined,
+        )
+        self.assertIn(
+            "range(H)",
+            combined,
+        )
+        self.assertIn(
+            "range(W)",
+            combined,
+        )
+        self.assertIn(
+            "solve(D, H, W, A)",
+            combined,
+        )
+
+    def test_generated_python_executes(self):
+        template = "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import sys",
+                "",
+                (
+                    'def solve(D: int, H: int, W: int, '
+                    'A: "List[List[List[int]]]"):'
+                ),
+                (
+                    "    print("
+                    "D, H, W, A[1][0][2], "
+                    "sum("
+                    "value "
+                    "for plane in A "
+                    "for row in plane "
+                    "for value in row"
+                    ")"
+                    ")"
+                ),
+                "",
+                "def main():",
+                "    def iterate_tokens():",
+                "        for line in sys.stdin:",
+                "            for word in line.split():",
+                "                yield word",
+                "",
+                "    tokens = iterate_tokens()",
+                "    {{ input_part_with_solve_function }}",
+                "",
+                "",
+                "if __name__ == '__main__':",
+                "    main()",
+                "",
+            ]
+        )
+
+        code = PYTHON.default_code_generator(
+            CodeGenArgs(
+                template=template,
+                format_=self.format,
+                constants=ProblemConstantSet(),
+                config=self.config,
+            )
+        )
+
+        sample_input = (
+            "2 2 3\n"
+            "1 2 3\n"
+            "4 5 6\n"
+            "7 8 9\n"
+            "10 11 12\n"
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(
+                directory,
+                "main.py",
+            )
+
+            with open(
+                path,
+                "w",
+                encoding="utf-8",
+            ) as file:
+                file.write(code)
+
+            compile_result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "py_compile",
+                    path,
+                ],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(
+                0,
+                compile_result.returncode,
+                compile_result.stderr,
+            )
+
+            run_result = subprocess.run(
+                [
+                    sys.executable,
+                    path,
+                ],
+                input=sample_input,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(
+                0,
+                run_result.returncode,
+                run_result.stderr,
+            )
+            self.assertEqual(
+                "2 2 3 9 78\n",
+                run_result.stdout,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_three_dimensional_codegen.py
+++ b/tests/test_three_dimensional_codegen.py
@@ -94,10 +94,47 @@ class TestThreeDimensionalCodeGenerator(unittest.TestCase):
             parameters["formal_arguments"],
         )
 
-        combined = parameters[
-            "input_part_with_solve_function"
-        ]
+        for key in (
+            "multi_case",
+            "input_part",
+            "prefix_input_part",
+            "case_input_part",
+            "case_count_var",
+            "case_loop_var",
+        ):
+            self.assertIn(
+                key,
+                parameters,
+            )
 
+        self.assertFalse(
+            parameters["multi_case"]
+        )
+        self.assertIsNone(
+            parameters["case_count_var"]
+        )
+        self.assertIsNone(
+            parameters["case_loop_var"]
+        )
+        self.assertNotIn(
+            "input_part_with_solve_function",
+            parameters,
+        )
+        self.assertNotIn(
+            "input_part_with_solve_function_nested",
+            parameters,
+        )
+
+        combined = parameters["input_part"]
+
+        self.assertEqual(
+            combined,
+            parameters["prefix_input_part"],
+        )
+        self.assertEqual(
+            combined,
+            parameters["case_input_part"],
+        )
         self.assertIn(
             "range(D)",
             combined,
@@ -110,8 +147,8 @@ class TestThreeDimensionalCodeGenerator(unittest.TestCase):
             "range(W)",
             combined,
         )
-        self.assertIn(
-            "solve(D, H, W, A)",
+        self.assertNotIn(
+            "solve(",
             combined,
         )
 
@@ -144,7 +181,16 @@ class TestThreeDimensionalCodeGenerator(unittest.TestCase):
                 "                yield word",
                 "",
                 "    tokens = iterate_tokens()",
-                "    {{ input_part_with_solve_function }}",
+                "    {% if multi_case %}",
+                (
+                    "    raise AssertionError("
+                    "'unexpected multi-case format'"
+                    ")"
+                ),
+                "    {% else %}",
+                "    {{ input_part }}",
+                "    solve({{ actual_arguments }})",
+                "    {% endif %}",
                 "",
                 "",
                 "if __name__ == '__main__':",

--- a/tests/test_three_dimensional_compact_rows.py
+++ b/tests/test_three_dimensional_compact_rows.py
@@ -1,0 +1,224 @@
+import subprocess
+import sys
+import unittest
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.codegen.code_generators.universal_code_generator import (
+    UniversalCodeGenerator,
+    get_builtin_code_generator_info_toml_path,
+)
+from atcodertools.codegen.code_style_config import CodeStyleConfig
+from atcodertools.common.language import PYTHON
+from atcodertools.fmtprediction.models.format import (
+    ThreeDimensionalPattern,
+    TwoDimensionalPattern,
+)
+from atcodertools.fmtprediction.models.type import Type
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+
+
+FIXED_COMPACT_FORMAT = """
+P_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}
+P_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}
+P_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}
+P_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}
+P_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}
+P_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}
+P_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}
+P_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}
+P_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}
+P_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}
+P_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}
+P_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}
+""".strip()
+
+FIXED_COMPACT_SAMPLE = """
+####
+....
+#...
+.#..
+..#.
+...#
+##..
+..##
+#.#.
+.#.#
+###.
+...#
+""".strip()
+
+VARIABLE_COMPACT_FORMAT = r"""
+D H W
+A_{1,1,1}A_{1,1,2}\ldots A_{1,1,W}
+A_{1,2,1}A_{1,2,2}\ldots A_{1,2,W}
+\vdots
+A_{1,H,1}A_{1,H,2}\ldots A_{1,H,W}
+\vdots
+A_{D,H,1}A_{D,H,2}\ldots A_{D,H,W}
+""".strip()
+
+VARIABLE_COMPACT_SAMPLE = """
+2 2 3
+.#.
+###
+..#
+#..
+""".strip()
+
+VARIABLE_SPACED_FORMAT = r"""
+D H W
+A_{1,1,1} A_{1,1,2} \ldots A_{1,1,W}
+A_{1,2,1} A_{1,2,2} \ldots A_{1,2,W}
+\vdots
+A_{1,H,1} A_{1,H,2} \ldots A_{1,H,W}
+\vdots
+A_{D,H,1} A_{D,H,2} \ldots A_{D,H,W}
+""".strip()
+
+VARIABLE_SPACED_SAMPLE = """
+2 2 3
+. # .
+# # #
+. . #
+# . .
+""".strip()
+
+
+def content(input_format, sample_input):
+    return ProblemContent(
+        input_format_text=input_format,
+        input_format_blocks=[input_format],
+        input_format_context_text="",
+        original_html="",
+        samples=[Sample(sample_input, "")],
+    )
+
+
+class TestThreeDimensionalCompactRows(unittest.TestCase):
+    def test_fixed_compact_rows_collapse_innermost_dimension(self):
+        result = predict_format(
+            content(
+                FIXED_COMPACT_FORMAT,
+                FIXED_COMPACT_SAMPLE,
+            )
+        )
+
+        self.assertEqual(1, len(result.format.sequence))
+        pattern = result.format.sequence[0]
+
+        self.assertIsInstance(
+            pattern,
+            TwoDimensionalPattern,
+        )
+        self.assertEqual("P", pattern.var.name)
+        self.assertEqual(Type.str, pattern.var.type)
+        self.assertEqual(2, pattern.var.dim_num())
+
+    def test_variable_compact_rows_collapse_innermost_dimension(self):
+        result = predict_format(
+            content(
+                VARIABLE_COMPACT_FORMAT,
+                VARIABLE_COMPACT_SAMPLE,
+            )
+        )
+        pattern = result.format.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            TwoDimensionalPattern,
+        )
+        self.assertEqual("A", pattern.var.name)
+        self.assertEqual(Type.str, pattern.var.type)
+        self.assertEqual(2, pattern.var.dim_num())
+
+    def test_spaced_character_elements_remain_three_dimensional(self):
+        result = predict_format(
+            content(
+                VARIABLE_SPACED_FORMAT,
+                VARIABLE_SPACED_SAMPLE,
+            )
+        )
+        pattern = result.format.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            ThreeDimensionalPattern,
+        )
+        self.assertEqual("A", pattern.var.name)
+        self.assertEqual(Type.str, pattern.var.type)
+        self.assertEqual(3, pattern.var.dim_num())
+
+    def test_generated_python_reads_compact_rows(self):
+        result = predict_format(
+            content(
+                FIXED_COMPACT_FORMAT,
+                FIXED_COMPACT_SAMPLE,
+            )
+        )
+
+        generator = UniversalCodeGenerator(
+            result.format,
+            CodeStyleConfig(
+                lang=PYTHON.name
+            ),
+            get_builtin_code_generator_info_toml_path(
+                PYTHON.name
+            ),
+        )
+        parameters = generator.generate_parameters()
+
+        self.assertIn(
+            "List[List[str]]",
+            parameters["formal_arguments"],
+        )
+
+        generated = "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "from typing import *",
+                "import sys",
+                "",
+                "def solve(P):",
+                (
+                    "    print("
+                    "len(P), len(P[0]), P[0][0]"
+                    ")"
+                ),
+                "",
+                "tokens = iter(sys.stdin.read().split())",
+                parameters["input_part"],
+                "solve(P)",
+                "",
+            ]
+        )
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                generated,
+            ],
+            input=FIXED_COMPACT_SAMPLE,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(
+            0,
+            completed.returncode,
+            msg=completed.stderr + "\n" + generated,
+        )
+        self.assertEqual(
+            "3 4 ####",
+            completed.stdout.strip(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_three_dimensional_official_cases.py
+++ b/tests/test_three_dimensional_official_cases.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+import unittest
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "resources"
+    / "test_three_dimensional"
+    / "official_cases.json"
+)
+
+
+class TestThreeDimensionalOfficialCases(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(
+            FIXTURE_PATH.read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def _content(self, case):
+        return ProblemContent(
+            input_format_text=case[
+                "input_format_text"
+            ],
+            input_format_blocks=case[
+                "input_format_blocks"
+            ],
+            input_format_context_text=case[
+                "input_format_context_text"
+            ],
+            original_html="",
+            samples=[
+                Sample(sample_input, "")
+                for sample_input
+                in case["sample_inputs"]
+            ],
+        )
+
+    def test_fixture_schema_and_count(self):
+        self.assertEqual(
+            (
+                "atcoder_tools_three_dimensional_"
+                "official_cases_v1"
+            ),
+            self.fixture["schema"],
+        )
+        self.assertEqual(
+            3,
+            len(self.fixture["cases"]),
+        )
+        self.assertEqual(
+            {
+                "abc080_c",
+                "abc322_d",
+                "abc366_d",
+            },
+            {
+                case["task_id"]
+                for case in self.fixture["cases"]
+            },
+        )
+
+    def test_official_prediction_contracts(self):
+        for case in self.fixture["cases"]:
+            with self.subTest(
+                task_id=case["task_id"]
+            ):
+                result = predict_format(
+                    self._content(case)
+                )
+                format_ = result.format
+
+                variables = {
+                    variable.name: variable
+                    for variable in format_.all_vars()
+                }
+
+                pattern_classes = {}
+
+                for pattern in format_.sequence:
+                    for variable in pattern.all_vars():
+                        pattern_classes[
+                            variable.name
+                        ] = type(pattern).__name__
+
+                for name, expected in case[
+                    "expected_variables"
+                ].items():
+                    self.assertIn(
+                        name,
+                        variables,
+                    )
+                    variable = variables[name]
+
+                    self.assertEqual(
+                        expected["type"],
+                        str(variable.type),
+                    )
+                    self.assertEqual(
+                        expected["dim_num"],
+                        variable.dim_num(),
+                    )
+
+                for name, expected_class in case[
+                    "expected_patterns"
+                ].items():
+                    self.assertEqual(
+                        expected_class,
+                        pattern_classes[name],
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_three_dimensional_official_cases.py
+++ b/tests/test_three_dimensional_official_cases.py
@@ -56,7 +56,7 @@ class TestThreeDimensionalOfficialCases(unittest.TestCase):
             self.fixture["schema"],
         )
         self.assertEqual(
-            3,
+            4,
             len(self.fixture["cases"]),
         )
         self.assertEqual(
@@ -64,6 +64,7 @@ class TestThreeDimensionalOfficialCases(unittest.TestCase):
                 "abc080_c",
                 "abc322_d",
                 "abc366_d",
+                "code_festival_2015_okinawa_c",
             },
             {
                 case["task_id"]

--- a/tests/test_three_dimensional_prediction.py
+++ b/tests/test_three_dimensional_prediction.py
@@ -1,0 +1,121 @@
+import unittest
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.models.format import (
+    ThreeDimensionalPattern,
+)
+from atcodertools.fmtprediction.models.type import Type
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+from atcodertools.fmtprediction.predict_simple_format import (
+    predict_simple_format,
+)
+from atcodertools.fmtprediction.tokenize_format import (
+    search_formats_with_minimum_vars,
+)
+
+
+INPUT_FORMAT = """
+D H W
+A_{1,1,1} ... A_{1,1,W}
+A_{1,H,1} ... A_{1,H,W}
+...
+A_{D,1,1} ... A_{D,1,W}
+A_{D,H,1} ... A_{D,H,W}
+"""
+
+SAMPLE_INPUT = """
+2 2 3
+1 2 3
+4 5 6
+7 8 9
+10 11 12
+"""
+
+
+class TestThreeDimensionalPrediction(unittest.TestCase):
+    def test_tokenizer_finds_three_indices(self):
+        candidates = (
+            search_formats_with_minimum_vars(
+                INPUT_FORMAT
+            )
+        )
+
+        matching = [
+            candidate
+            for candidate in candidates
+            if any(
+                token.var_name == "A"
+                and token.dim_num() == 3
+                and token.first_index == "1"
+                and token.second_index == "1"
+                and token.third_index == "1"
+                for token in candidate.var_tokens
+            )
+        ]
+
+        self.assertTrue(matching)
+
+    def test_simple_format_contains_3d_pattern(self):
+        candidates = (
+            search_formats_with_minimum_vars(
+                INPUT_FORMAT
+            )
+        )
+
+        tokenized = next(
+            candidate
+            for candidate in candidates
+            if any(
+                token.var_name == "A"
+                and token.dim_num() == 3
+                for token in candidate.var_tokens
+            )
+        )
+
+        format_ = predict_simple_format(
+            tokenized.var_tokens
+        )
+
+        pattern = format_.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            ThreeDimensionalPattern,
+        )
+        self.assertEqual(3, pattern.var.dim_num())
+
+    def test_end_to_end_type_prediction(self):
+        content = ProblemContent(
+            INPUT_FORMAT,
+            [Sample(SAMPLE_INPUT, None)],
+        )
+
+        result = predict_format(content)
+        format_ = result.format
+        pattern = format_.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            ThreeDimensionalPattern,
+        )
+        self.assertEqual(
+            ["D", "H", "W", "A"],
+            [
+                variable.name
+                for variable in format_.all_vars()
+            ],
+        )
+        self.assertEqual(Type.int, pattern.var.type)
+        self.assertEqual(3, pattern.var.dim_num())
+        self.assertIsNotNone(
+            pattern.var.third_index
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

3次元配列として記述された入力形式の推定とコード生成に対応します。

## 主な変更

- 3つの添字を持つ変数を3次元配列として認識
- 整数3次元配列の入力コードを生成
- 3次元文字グリッドの連結行入力では、最内次元を文字列として縮約
- 公式問題を用いた入力形式fixtureを追加

## 対象例

- ABC080 C
- ABC322 D
- ABC366 D
- CODE FESTIVAL 2015 沖縄 C

## 検証

- 最新stable HEAD: `cde604d0afdbf0a3c9162f447f01648cbad44a48`
- corpus 2,279件: `2017 -> 2019`
- 新規成功: 2件
- 既存成功からの退行: 0件
- 3D関連テスト: PASS
- worktree: clean

## 関連

複数テストケース対応の #315 マージ後のstableへrebase済みです。
