### PR TITLE
入力形式予測の決定的カバレッジを改善（#314・#258補完）

### DIFF
--- a/atcodertools/codegen/code_generators/universal_code_generator.py
+++ b/atcodertools/codegen/code_generators/universal_code_generator.py
@@ -9,6 +9,7 @@ from atcodertools.fmtprediction.models.format import (
     Pattern,
     RepeatedCaseFormat,
     SingularPattern,
+    ThreeDimensionalPattern,
     TwoDimensionalPattern,
 )
 from atcodertools.fmtprediction.models.type import Type
@@ -36,6 +37,10 @@ class UniversalCodeGenerator():
                 "j": "j",
             }
 
+        self.info.setdefault("index", {})
+        self.info["index"].setdefault("i", "i")
+        self.info["index"].setdefault("j", "j")
+        self.info["index"].setdefault("k", "k")
         self._prefix_format = format_
         self._solve_format = format_
         self._case_count_var = None
@@ -52,8 +57,16 @@ class UniversalCodeGenerator():
     def _get_length(self, index) -> str:
         return self._insert_space_around_operators(str(index.get_length()))
 
-    def _loop_header(self, var: Variable, for_second_index: bool):
-        if for_second_index:
+    def _loop_header(
+        self,
+        var: Variable,
+        for_second_index: bool,
+        for_third_index: bool = False,
+    ):
+        if for_third_index:
+            index = var.third_index
+            loop_var = self.info["index"]["k"]
+        elif for_second_index:
             index = var.second_index
             loop_var = self.info["index"]["j"]
         else:
@@ -62,7 +75,7 @@ class UniversalCodeGenerator():
 
         return self.info["loop"]["header"].format(
             loop_var=loop_var,
-            length=self._get_length(index)
+            length=self._get_length(index),
         )
 
     def _insert_space_around_operators(self, code: str):
@@ -234,32 +247,71 @@ class UniversalCodeGenerator():
     def _get_input_func(self, type_: Type) -> str:
         return self.info["input_func"][type_.value]
 
-    def _get_format_keywords(self, var: Variable) -> dict:
-        result = {"name": var.name, "type": self._convert_type(
-            var.type), "default": self._default_val(var.type)}
+    def _get_format_keywords(
+        self,
+        var: Variable,
+    ) -> dict:
+        result = {
+            "name": var.name,
+            "type": self._convert_type(var.type),
+            "default": self._default_val(var.type),
+        }
+
         if "input_func" in self.info:
-            result["input_func"] = self._get_input_func(var.type)
+            result["input_func"] = (
+                self._get_input_func(var.type)
+            )
+
         if var.dim_num() == 0:
             pass
         elif var.dim_num() == 1:
-            result["length"] = self._get_length(var.first_index)
+            result["length"] = self._get_length(
+                var.first_index
+            )
         elif var.dim_num() == 2:
-            result.update({"length_i": self._get_length(
-                var.first_index), "length_j": self._get_length(var.second_index)})
+            result.update(
+                {
+                    "length_i": self._get_length(
+                        var.first_index
+                    ),
+                    "length_j": self._get_length(
+                        var.second_index
+                    ),
+                }
+            )
+        elif var.dim_num() == 3:
+            result.update(
+                {
+                    "length_i": self._get_length(
+                        var.first_index
+                    ),
+                    "length_j": self._get_length(
+                        var.second_index
+                    ),
+                    "length_k": self._get_length(
+                        var.third_index
+                    ),
+                }
+            )
         else:
             raise NotImplementedError
-        # TODO: index_i, index_jは含めなくていいか？
+
         return result
 
-    def _get_variable_kind(self, var: Variable) -> str:
+    def _get_variable_kind(
+        self,
+        var: Variable,
+    ) -> str:
         if var.dim_num() == 0:
             return var.type.value
-        elif var.dim_num() == 1:
+        if var.dim_num() == 1:
             return "seq"
-        elif var.dim_num() == 2:
+        if var.dim_num() == 2:
             return "2d_seq"
-        else:
-            raise NotImplementedError
+        if var.dim_num() == 3:
+            return "3d_seq"
+
+        raise NotImplementedError
 
     def _get_argument(self, var: Variable):
         kwd = self._get_format_keywords(var)
@@ -340,14 +392,29 @@ class UniversalCodeGenerator():
 
     def _get_var_name(self, var: Variable):
         name = var.name
+
         if var.dim_num() == 0:
             return name
-        elif var.dim_num() == 1:
-            return self.info["access"]["seq"].format(name=name, index=self.info["index"]["i"])
-        elif var.dim_num() == 2:
-            return self.info["access"]["2d_seq"].format(name=name, index_i=self.info["index"]["i"], index_j=self.info["index"]["j"])
-        else:
-            raise NotImplementedError
+        if var.dim_num() == 1:
+            return self.info["access"]["seq"].format(
+                name=name,
+                index=self.info["index"]["i"],
+            )
+        if var.dim_num() == 2:
+            return self.info["access"]["2d_seq"].format(
+                name=name,
+                index_i=self.info["index"]["i"],
+                index_j=self.info["index"]["j"],
+            )
+        if var.dim_num() == 3:
+            return self.info["access"]["3d_seq"].format(
+                name=name,
+                index_i=self.info["index"]["i"],
+                index_j=self.info["index"]["j"],
+                index_k=self.info["index"]["k"],
+            )
+
+        raise NotImplementedError
 
     def _append(self, lines, s, indent=0):
         if s == "":
@@ -379,58 +446,229 @@ class UniversalCodeGenerator():
         self._append_declaration_and_allocation(lines, pattern, global_mode)
         self._append(lines, self._input_code_for_var(var))
 
-    def _render_pattern(self, pattern: Pattern, global_mode):
+    def _render_pattern(
+        self,
+        pattern: Pattern,
+        global_mode,
+    ):
         lines = []
+        representative_var = (
+            pattern.all_vars()[0]
+        )
 
-        representative_var = pattern.all_vars()[0]
         if isinstance(pattern, SingularPattern):
-            self._append_singular_pattern(lines, pattern, global_mode)
+            self._append_singular_pattern(
+                lines,
+                pattern,
+                global_mode,
+            )
+
         elif isinstance(pattern, ParallelPattern):
             added = False
+
             if len(pattern.all_vars()) == 1:
                 var = pattern.all_vars()[0]
                 kwd = self._get_format_keywords(var)
+
                 if global_mode:
                     op = "allocate_and_input"
                 else:
-                    op = "declare_and_allocate_and_input"
+                    op = (
+                        "declare_and_allocate_and_input"
+                    )
+
                 if op in self.info:
-                    self._append(lines, self.info[op]["seq"].format(**kwd))
+                    self._append(
+                        lines,
+                        self.info[op]["seq"].format(
+                            **kwd
+                        ),
+                    )
                     added = True
+
             if not added:
                 self._append_declaration_and_allocation(
-                    lines, pattern, global_mode)
-                self._append(lines, self._loop_header(
-                    representative_var, False))
+                    lines,
+                    pattern,
+                    global_mode,
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                    ),
+                )
+
                 for var in pattern.all_vars():
-                    self._append(lines, self._input_code_for_var(var), 1)
-                self._append(lines, self.info["loop"]["footer"].format())
-        elif isinstance(pattern, TwoDimensionalPattern):
+                    self._append(
+                        lines,
+                        self._input_code_for_var(var),
+                        1,
+                    )
+
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(),
+                )
+
+        elif isinstance(
+            pattern,
+            TwoDimensionalPattern,
+        ):
             added = False
+
             if len(pattern.all_vars()) == 1:
                 var = pattern.all_vars()[0]
                 kwd = self._get_format_keywords(var)
+
                 if global_mode:
                     op = "allocate_and_input"
                 else:
-                    op = "declare_and_allocate_and_input"
+                    op = (
+                        "declare_and_allocate_and_input"
+                    )
+
                 if op in self.info:
-                    self._append(lines, self.info[op]["2d_seq"].format(**kwd))
+                    self._append(
+                        lines,
+                        self.info[op]["2d_seq"].format(
+                            **kwd
+                        ),
+                    )
                     added = True
+
             if not added:
                 self._append_declaration_and_allocation(
-                    lines, pattern, global_mode)
+                    lines,
+                    pattern,
+                    global_mode,
+                )
                 self._append(
-                    lines, self._loop_header(representative_var, False))
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                    ),
+                )
                 self._append(
-                    lines, self._loop_header(representative_var, True), 1)
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        True,
+                    ),
+                    1,
+                )
+
                 for var in pattern.all_vars():
-                    self._append(lines, self._input_code_for_var(var), 2)
-                # loop_varを指定してるのはVisual Basicなどfooterにループの変数書かなきゃいけない言語向けのつもり
-                self._append(lines, self.info["loop"]["footer"].format(
-                    loop_var=self.info["index"]["j"]), 1)
-                self._append(lines, self.info["loop"]["footer"].format(
-                    loop_var=self.info["index"]["i"]))
+                    self._append(
+                        lines,
+                        self._input_code_for_var(var),
+                        2,
+                    )
+
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["j"]
+                    ),
+                    1,
+                )
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["i"]
+                    ),
+                )
+
+        elif isinstance(
+            pattern,
+            ThreeDimensionalPattern,
+        ):
+            added = False
+
+            if len(pattern.all_vars()) == 1:
+                var = pattern.all_vars()[0]
+                kwd = self._get_format_keywords(var)
+
+                if global_mode:
+                    op = "allocate_and_input"
+                else:
+                    op = (
+                        "declare_and_allocate_and_input"
+                    )
+
+                if (
+                    op in self.info
+                    and "3d_seq" in self.info[op]
+                ):
+                    self._append(
+                        lines,
+                        self.info[op]["3d_seq"].format(
+                            **kwd
+                        ),
+                    )
+                    added = True
+
+            if not added:
+                self._append_declaration_and_allocation(
+                    lines,
+                    pattern,
+                    global_mode,
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                    ),
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        True,
+                    ),
+                    1,
+                )
+                self._append(
+                    lines,
+                    self._loop_header(
+                        representative_var,
+                        False,
+                        True,
+                    ),
+                    2,
+                )
+
+                for var in pattern.all_vars():
+                    self._append(
+                        lines,
+                        self._input_code_for_var(var),
+                        3,
+                    )
+
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["k"]
+                    ),
+                    2,
+                )
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["j"]
+                    ),
+                    1,
+                )
+                self._append(
+                    lines,
+                    self.info["loop"]["footer"].format(
+                        loop_var=self.info["index"]["i"]
+                    ),
+                )
+
         else:
             raise NotImplementedError
 

--- a/atcodertools/codegen/code_generators/universal_generator/python.toml
+++ b/atcodertools/codegen/code_generators/universal_generator/python.toml
@@ -10,6 +10,7 @@ i = "i"
 j = "j"
 
 # ループ
+k = "k"
 [loop]
 header = "for {loop_var} in range({length}):"
 footer = ""
@@ -35,16 +36,19 @@ seq = ""
 2d_seq = ""
 
 # 確保
+3d_seq = ""
 [allocate]
 seq = "{name} = [{default}] * ({length})"
 2d_seq = "{name} = [[{default}] * ({length_j}) for _ in {length_i}]"
 
 # 宣言と確保
+3d_seq = "{name} = [[[{default}] * ({length_k}) for _ in range({length_j})] for _ in range({length_i})]"
 [declare_and_allocate]
 seq = "{name} = [{default}] * ({length})  # type: \"List[{type}]\""
 self.declare_and_allocate_2d_seq = "{name} = [[{default}] * ({length_j}) for _ in {length_i}]  # type: \"List[List[{type}]]\""
 
 # 入力関数
+3d_seq = "{name} = [[[{default}] * ({length_k}) for _ in range({length_j})] for _ in range({length_i})] # type: \"List[List[List[{type}]]]\""
 [input_func]
 int = "int(next(tokens))"
 float = "float(next(tokens))"
@@ -68,11 +72,13 @@ seq = "{name} = [{input_func} for _ in range({length})]"
 2d_seq = "{name} = [[{input_func} for _ in range({length_j})] for _ in range({length_i})]"
 
 # 宣言と確保と入力
+3d_seq = "{name} = [[[{input_func} for _ in range({length_k})] for _ in range({length_j})] for _ in range({length_i})]"
 [declare_and_allocate_and_input]
 seq = "{name} = [{input_func} for _ in range({length})]  # type: \"List[{type}]\""
 2d_seq = "{name} = [[{input_func} for _ in range({length_j})] for _ in range({length_i})]  # type: \"List[List[{type}]]\""
 
 # 引数
+3d_seq = "{name} = [[[{input_func} for _ in range({length_k})] for _ in range({length_j})] for _ in range({length_i})] # type: \"List[List[List[{type}]]]\""
 [arg]
 int = "{name}: int"
 float = "{name}: float"
@@ -81,6 +87,8 @@ seq = "{name}: \"List[{type}]\""
 2d_seq = "{name}: \"List[List[{type}]]\""
 
 # 配列アクセス
+3d_seq = "{name}: \"List[List[List[{type}]]]\""
 [access]
 seq = "{name}[{index}]"
 2d_seq = "{name}[{index_i}][{index_j}]"
+3d_seq = "{name}[{index_i}][{index_j}][{index_k}]"

--- a/atcodertools/fmtprediction/models/calculator.py
+++ b/atcodertools/fmtprediction/models/calculator.py
@@ -43,6 +43,13 @@ def div(a, b):
         raise EvaluateError(e)
 
 
+def power(a, b):
+    try:
+        return a ** b
+    except TypeError as e:
+        raise EvaluateError(e)
+
+
 def _operator_to_string(operator):
     if operator == add:
         return "+"
@@ -52,6 +59,8 @@ def _operator_to_string(operator):
         return "*"
     elif operator == div:
         return "/"
+    elif operator == power:
+        return "^"
     else:
         raise UnknownOperatorError
 
@@ -187,13 +196,26 @@ def _expr(formula, pos):
 
 
 def _term(formula, pos):
-    res, pos = _factor(formula, pos)
+    res, pos = _power(formula, pos)
     while formula[pos] == '*' or formula[pos] == '/':
         tmp = CalcNode()
         tmp.operator = mul if formula[pos] == '*' else div
         pos += 1
         tmp.lch = res
-        tmp.rch, pos = _factor(formula, pos)
+        tmp.rch, pos = _power(formula, pos)
+        res = tmp
+    return res, pos
+
+
+def _power(formula, pos):
+    res, pos = _factor(formula, pos)
+    if formula[pos] == '^':
+        tmp = CalcNode()
+        tmp.operator = power
+        pos += 1
+        tmp.lch = res
+        # exponentiation is right-associative (e.g. 2^N)
+        tmp.rch, pos = _power(formula, pos)
         res = tmp
     return res, pos
 

--- a/atcodertools/fmtprediction/models/format.py
+++ b/atcodertools/fmtprediction/models/format.py
@@ -114,6 +114,30 @@ class TwoDimensionalPattern(Pattern):
         return TwoDimensionalPattern(name_to_var[self.var.name])
 
 
+class ThreeDimensionalPattern(Pattern):
+    """A three-dimensional dense array."""
+
+    def __init__(self, var: T):
+        self.var = var
+
+    def __str__(self):
+        return (
+            "(ThreeDimensional: {})"
+            .format(self.var.name)
+        )
+
+    def all_vars(self):
+        return [self.var]
+
+    def with_replaced_vars(
+        self,
+        name_to_var: Dict[str, Variable],
+    ):
+        return ThreeDimensionalPattern(
+            name_to_var[self.var.name]
+        )
+
+
 class ParallelPattern(Pattern):
 
     """

--- a/atcodertools/fmtprediction/models/format_prediction_result.py
+++ b/atcodertools/fmtprediction/models/format_prediction_result.py
@@ -33,13 +33,16 @@ class FormatPredictionResult:
                 var.first_index,
                 var.second_index,
                 var_to_type[var.name],
+                third_index=var.third_index,
             )
 
         typed_format = Format()
 
         for pattern in simple_format.sequence:
             typed_format.push_back(
-                pattern.with_replaced_vars(var_to_info)
+                pattern.with_replaced_vars(
+                    var_to_info
+                )
             )
 
         return typed_format

--- a/atcodertools/fmtprediction/models/variable.py
+++ b/atcodertools/fmtprediction/models/variable.py
@@ -5,16 +5,21 @@ from atcodertools.fmtprediction.models.type import Type
 
 
 class SimpleVariable:
-
-    def __init__(self,
-                 name: str,
-                 first_index: Optional[Index],
-                 second_index: Optional[Index]):
+    def __init__(
+        self,
+        name: str,
+        first_index: Optional[Index],
+        second_index: Optional[Index],
+        third_index: Optional[Index] = None,
+    ):
         self.name = name
         self.first_index = first_index
         self.second_index = second_index
+        self.third_index = third_index
 
     def dim_num(self):
+        if self.third_index:
+            return 3
         if self.second_index:
             return 2
         if self.first_index:
@@ -23,29 +28,42 @@ class SimpleVariable:
 
     @classmethod
     def create(cls, name: str, dim_num: int):
-        assert dim_num <= 2
+        assert dim_num <= 3
 
         first_index = None
         second_index = None
+        third_index = None
 
+        if dim_num >= 3:
+            third_index = Index()
         if dim_num >= 2:
             second_index = Index()
         if dim_num >= 1:
             first_index = Index()
 
-        return SimpleVariable(name, first_index, second_index)
+        return SimpleVariable(
+            name,
+            first_index,
+            second_index,
+            third_index,
+        )
 
 
 class Variable(SimpleVariable):
+    """SimpleVariable + type information."""
 
-    """
-        SimpleVariable + type information
-    """
-
-    def __init__(self,
-                 name: str,
-                 first_index: Optional[Index],
-                 second_index: Optional[Index],
-                 type_: Type):
-        super().__init__(name, first_index, second_index)
+    def __init__(
+        self,
+        name: str,
+        first_index: Optional[Index],
+        second_index: Optional[Index],
+        type_: Type,
+        third_index: Optional[Index] = None,
+    ):
+        super().__init__(
+            name,
+            first_index,
+            second_index,
+            third_index,
+        )
         self.type = type_

--- a/atcodertools/fmtprediction/models/variable_token.py
+++ b/atcodertools/fmtprediction/models/variable_token.py
@@ -1,33 +1,46 @@
 import re
-from typing import Optional, List
+from typing import List, Optional
 
 
-VALID_VAR_NAME_REG_EXP = re.compile("[a-zA-Z_]+")
+VALID_VAR_NAME_REG_EXP = re.compile(
+    "[a-zA-Z_]+"
+)
 
 
 class VariableToken:
-
     """
-    This model is used on the tokenization stage to store variable information with all string indices
-    This class supports up to 2 dimensions.
+    Variable information used during format tokenization.
+
+    Up to three indices are supported.
     """
 
-    def __init__(self, var_name: str, first_index: Optional[str], second_index: Optional[str]):
-        def normalize(x: str):
-            if x is None:
+    def __init__(
+        self,
+        var_name: str,
+        first_index: Optional[str],
+        second_index: Optional[str],
+        third_index: Optional[str] = None,
+    ):
+        def normalize(value):
+            if value is None:
                 return None
-            return x.rstrip(",")
+            return value.rstrip(",")
 
-        def fixed_var_name(x: str):
-            if x[-1] == "_":
-                return x[:-1]
-            return x
+        def fixed_var_name(value):
+            if value.endswith("_"):
+                return value[:-1]
+            return value
 
-        self.var_name = fixed_var_name(normalize(var_name))
+        self.var_name = fixed_var_name(
+            normalize(var_name)
+        )
         self.first_index = normalize(first_index)
         self.second_index = normalize(second_index)
+        self.third_index = normalize(third_index)
 
     def dim_num(self):
+        if self.third_index:
+            return 3
         if self.second_index:
             return 2
         if self.first_index:
@@ -37,14 +50,24 @@ class VariableToken:
     def is_valid(self):
         if not self._has_valid_var_name():
             return False
-        if not self._is_valid_index(self.first_index):
-            return False
-        if not self._is_valid_index(self.second_index):
-            return False
+
+        for index in (
+            self.first_index,
+            self.second_index,
+            self.third_index,
+        ):
+            if not self._is_valid_index(index):
+                return False
+
         return True
 
     def _has_valid_var_name(self):
-        return VALID_VAR_NAME_REG_EXP.fullmatch(self.var_name) is not None
+        return (
+            VALID_VAR_NAME_REG_EXP.fullmatch(
+                self.var_name
+            )
+            is not None
+        )
 
     @staticmethod
     def _is_valid_index(index):
@@ -52,14 +75,19 @@ class VariableToken:
             return True
         if len(index) == 0:
             return False
-        if not index[-1].isalpha() and not index[-1].isdigit():
+        if (
+            not index[-1].isalpha()
+            and not index[-1].isdigit()
+        ):
             return False
-        if index.find(',') != -1:
+        if index.find(",") != -1:
             return False
         return True
 
 
 class TokenizedFormat:
-
-    def __init__(self, var_tokens: List[VariableToken]):
+    def __init__(
+        self,
+        var_tokens: List[VariableToken],
+    ):
         self.var_tokens = var_tokens

--- a/atcodertools/fmtprediction/predict_format.py
+++ b/atcodertools/fmtprediction/predict_format.py
@@ -205,6 +205,148 @@ def _format_variable_names(format_: Format):
     }
 
 
+
+def _normalized_wrapper_placeholder_name(
+    variable_name,
+):
+    normalized = variable_name.lower()
+
+    prefixes = (
+        "mathrm",
+        "text",
+        "rm",
+        "it",
+    )
+
+    changed = True
+
+    while changed:
+        changed = False
+
+        for prefix in prefixes:
+            if normalized.startswith(prefix):
+                normalized = normalized[
+                    len(prefix):
+                ]
+                changed = True
+                break
+
+    return normalized
+
+
+def _is_wrapper_placeholder_split_candidate(
+    candidate,
+    wrapper,
+):
+    if candidate.layout != "split":
+        return False
+
+    if wrapper.layout != "wrapper":
+        return False
+
+    if (
+        candidate.case_count_var
+        != wrapper.case_count_var
+    ):
+        return False
+
+    if (
+        str(candidate.case_format)
+        != str(wrapper.case_format)
+    ):
+        return False
+
+    wrapper_names = (
+        _format_variable_names(
+            wrapper.prefix_format
+        )
+    )
+
+    candidate_variables = (
+        candidate.prefix_format.all_vars()
+    )
+
+    candidate_names = {
+        variable.name
+        for variable in candidate_variables
+    }
+
+    if not wrapper_names.issubset(
+        candidate_names
+    ):
+        return False
+
+    if candidate_names == wrapper_names:
+        return False
+
+    extra_variables = [
+        variable
+        for variable in candidate_variables
+        if variable.name
+        not in wrapper_names
+    ]
+
+    if not extra_variables:
+        return False
+
+    prefix_text = str(
+        candidate.prefix_format
+    )
+
+    for variable in extra_variables:
+        if variable.dim_num() != 1:
+            return False
+
+        placeholder_name = (
+            _normalized_wrapper_placeholder_name(
+                variable.name
+            )
+        )
+
+        if placeholder_name not in {
+            "case",
+            "test",
+        }:
+            return False
+
+        expected_pattern = (
+            "(Parallel: {} | 1 to {})"
+            .format(
+                variable.name,
+                candidate.case_count_var,
+            )
+        )
+
+        if expected_pattern not in prefix_text:
+            return False
+
+    return True
+
+
+def _prefer_explicit_wrapper_candidates(
+    candidates,
+):
+    wrapper_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate.layout == "wrapper"
+    ]
+
+    if not wrapper_candidates:
+        return candidates
+
+    return [
+        candidate
+        for candidate in candidates
+        if not any(
+            _is_wrapper_placeholder_split_candidate(
+                candidate,
+                wrapper,
+            )
+            for wrapper in wrapper_candidates
+        )
+    ]
+
 def _validate_candidate_on_samples(
     prefix_format: Format,
     case_format: Format,
@@ -888,6 +1030,13 @@ def predict_multi_case_format(
                             layout,
                         )
                     )
+
+
+    valid_predictions = (
+        _prefer_explicit_wrapper_candidates(
+            valid_predictions
+        )
+    )
 
     if not valid_predictions:
         raise NoMultiCaseFormatFoundError

--- a/atcodertools/fmtprediction/predict_format.py
+++ b/atcodertools/fmtprediction/predict_format.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, List
 
 from atcodertools.client.models.problem_content import (
@@ -34,6 +35,10 @@ from atcodertools.fmtprediction.token_manager import TokenManager
 from atcodertools.fmtprediction.tokenize_format import (
     NoFormatFoundError,
     search_formats_with_minimum_vars,
+)
+
+from atcodertools.fmtprediction.tokenize_format import (
+    collapse_string_runs,
 )
 
 
@@ -74,7 +79,7 @@ class MultiCaseFormatPrediction:
         self.layout = layout
 
 
-def _predict_simple_format_candidate_groups(
+def _predict_simple_format_candidate_groups_without_string_collapse(
     input_format_text: str,
 ) -> List[List[Format]]:
     """
@@ -120,6 +125,32 @@ def _predict_simple_format_candidate_groups(
             groups.append(group)
 
     return groups
+
+
+def _predict_simple_format_candidate_groups(
+    input_format_text: str,
+):
+    candidate_groups = list(
+        _predict_simple_format_candidate_groups_without_string_collapse(
+            input_format_text
+        )
+    )
+
+    if candidate_groups:
+        return candidate_groups
+
+    collapsed_input_format = collapse_string_runs(
+        input_format_text
+    )
+
+    if collapsed_input_format == input_format_text:
+        return []
+
+    return list(
+        _predict_simple_format_candidate_groups_without_string_collapse(
+            collapsed_input_format
+        )
+    )
 
 
 def _predict_simple_format_candidates(
@@ -238,15 +269,14 @@ def _validate_candidate_on_samples(
     return merged_types
 
 
-def _predict_single_case(
-    content: ProblemContent,
-) -> FormatPredictionResult:
-    input_format = content.get_input_format()
-    samples = content.get_samples()
+def _collect_single_case_candidates(
+    input_format: str,
+    samples,
+):
     output_candidates = []
 
     for candidate_group in (
-        _predict_simple_format_candidate_groups(
+        _predict_simple_format_candidate_groups_without_string_collapse(
             input_format
         )
     ):
@@ -266,10 +296,476 @@ def _predict_single_case(
                 )
             )
 
-            # Preserve the historical behavior: once one variant of a
-            # tokenized candidate passes type prediction, do not try its
-            # one-dimensional fallback.
             break
+
+    return output_candidates
+
+
+def _deduplicate_candidates(
+    candidates,
+):
+    deduplicated = []
+    seen = set()
+
+    for candidate in candidates:
+        signature = str(
+            candidate.format
+        )
+
+        if signature in seen:
+            continue
+
+        seen.add(signature)
+        deduplicated.append(
+            candidate
+        )
+
+    return deduplicated
+
+
+def _candidate_string_dimensions(
+    candidate,
+):
+    dimensions = {}
+
+    for variable in (
+        candidate.format.all_vars()
+    ):
+        if str(variable.type) != "Type.str":
+            continue
+
+        dimensions[variable.name] = (
+            variable.dim_num()
+        )
+
+    return dimensions
+
+
+def _contains_two_index_variable(
+    input_format,
+    variable_name,
+):
+    escaped_name = re.escape(
+        variable_name
+    )
+
+    pattern = (
+        escaped_name
+        + r"_\{[^{}\n]*,[^{}\n]*\}"
+    )
+
+    return (
+        re.search(
+            pattern,
+            input_format,
+        )
+        is not None
+    )
+
+
+def _contains_one_index_variable(
+    input_format,
+    variable_name,
+):
+    escaped_name = re.escape(
+        variable_name
+    )
+
+    pattern = (
+        escaped_name
+        + r"_\{[^{},\n]+\}"
+    )
+
+    return (
+        re.search(
+            pattern,
+            input_format,
+        )
+        is not None
+    )
+
+
+def _samples_are_single_token_rows(
+    samples,
+):
+    found_body = False
+
+    for sample in samples:
+        lines = (
+            sample.get_input()
+            .splitlines()
+        )
+
+        if len(lines) < 2:
+            return False
+
+        body_lines = [
+            line
+            for line in lines[1:]
+            if line != ""
+        ]
+
+        if not body_lines:
+            return False
+
+        if any(
+            len(line.split()) != 1
+            for line in body_lines
+        ):
+            return False
+
+        found_body = True
+
+    return found_body
+
+
+def _is_structural_string_grid_collapse(
+    original_candidate,
+    collapsed_candidate,
+    input_format,
+    collapsed_input_format,
+    samples,
+):
+    if not _samples_are_single_token_rows(
+        samples
+    ):
+        return False
+
+    original_dimensions = (
+        _candidate_string_dimensions(
+            original_candidate
+        )
+    )
+    collapsed_dimensions = (
+        _candidate_string_dimensions(
+            collapsed_candidate
+        )
+    )
+
+    shared_names = (
+        set(original_dimensions)
+        & set(collapsed_dimensions)
+    )
+
+    matching_names = []
+
+    for name in shared_names:
+        if (
+            collapsed_dimensions[name] != 1
+        ):
+            continue
+
+        if (
+            original_dimensions[name]
+            not in (1, 2)
+        ):
+            continue
+
+        if not _contains_two_index_variable(
+            input_format,
+            name,
+        ):
+            continue
+
+        if not _contains_one_index_variable(
+            collapsed_input_format,
+            name,
+        ):
+            continue
+
+        matching_names.append(name)
+
+    return len(matching_names) == 1
+
+
+def _collapse_spaced_grid_row(
+    line,
+):
+    tokens = line.split()
+
+    if len(tokens) < 3:
+        return line
+
+    references = []
+
+    for token in tokens:
+        match = re.fullmatch(
+            (
+                r"(?P<name>"
+                r"[A-Za-z][A-Za-z0-9_]*"
+                r")_\{\s*"
+                r"(?P<outer>[^,{}]+?)"
+                r"\s*,\s*"
+                r"(?P<inner>[^{}]+?)"
+                r"\s*\}"
+            ),
+            token,
+        )
+
+        if match is None:
+            return line
+
+        references.append(
+            (
+                match.group("name"),
+                match.group("outer"),
+                match.group("inner"),
+            )
+        )
+
+    names = {
+        name
+        for name, _, _
+        in references
+    }
+
+    outer_indices = {
+        outer
+        for _, outer, _
+        in references
+    }
+
+    inner_indices = {
+        inner
+        for _, _, inner
+        in references
+    }
+
+    if (
+        len(names) != 1
+        or len(outer_indices) != 1
+        or len(inner_indices) < 2
+    ):
+        return line
+
+    name = references[0][0]
+    outer = references[0][1]
+
+    return "{}_{{{}}}".format(
+        name,
+        outer,
+    )
+
+
+def _collapse_spaced_grid_rows(
+    input_format,
+):
+    return "\n".join(
+        _collapse_spaced_grid_row(
+            line
+        )
+        for line in input_format.split(
+            "\n"
+        )
+    )
+
+
+def _collapse_compact_digit_grid_row(
+    line,
+):
+    references = list(
+        re.finditer(
+            (
+                r"(?P<name>"
+                r"[A-Za-z][A-Za-z0-9_]*"
+                r")_\{"
+                r"(?P<combined>"
+                r"[A-Za-z0-9+\-]+"
+                r")\}"
+            ),
+            line,
+        )
+    )
+
+    if len(references) < 3:
+        return line
+
+    names = {
+        match.group("name")
+        for match in references
+    }
+
+    if len(names) != 1:
+        return line
+
+    combined_indices = [
+        match.group("combined")
+        for match in references
+    ]
+
+    if any(
+        len(index) < 2
+        for index in combined_indices
+    ):
+        return line
+
+    outer_indices = {
+        index[:-1]
+        for index in combined_indices
+    }
+
+    inner_indices = {
+        index[-1]
+        for index in combined_indices
+    }
+
+    if (
+        len(outer_indices) != 1
+        or len(inner_indices) < 2
+    ):
+        return line
+
+    reference_span = line[
+        references[0].start():
+        references[-1].end()
+    ]
+
+    if any(
+        character.isspace()
+        for character in reference_span
+    ):
+        return line
+
+    if not (
+        "..." in reference_span
+        or "…" in reference_span
+        or "‥" in reference_span
+    ):
+        return line
+
+    name = references[0].group(
+        "name"
+    )
+    outer = next(
+        iter(outer_indices)
+    )
+
+    return "{}_{{{}}}".format(
+        name,
+        outer,
+    )
+
+
+def _collapse_compact_digit_grid_rows(
+    input_format,
+):
+    return "\n".join(
+        _collapse_compact_digit_grid_row(
+            line
+        )
+        for line in input_format.split(
+            "\n"
+        )
+    )
+
+
+def _predict_single_case(
+    content: ProblemContent,
+) -> FormatPredictionResult:
+    input_format = content.get_input_format()
+    samples = content.get_samples()
+
+    original_candidates = (
+        _deduplicate_candidates(
+            _collect_single_case_candidates(
+                input_format,
+                samples,
+            )
+        )
+    )
+
+    collapsed_input_format = (
+        collapse_string_runs(
+            input_format
+        )
+    )
+
+    collapsed_candidates = []
+
+    if collapsed_input_format != input_format:
+        collapsed_candidates = (
+            _deduplicate_candidates(
+                _collect_single_case_candidates(
+                    collapsed_input_format,
+                    samples,
+                )
+            )
+        )
+
+    spaced_grid_candidates = []
+
+    if (
+        not original_candidates
+        and not collapsed_candidates
+    ):
+        spaced_grid_input_format = (
+            _collapse_spaced_grid_rows(
+                input_format
+            )
+        )
+
+        if spaced_grid_input_format != input_format:
+            spaced_grid_candidates = (
+                _deduplicate_candidates(
+                    _collect_single_case_candidates(
+                        spaced_grid_input_format,
+                        samples,
+                    )
+                )
+            )
+
+    compact_digit_grid_candidates = []
+
+    if (
+        not original_candidates
+        and not collapsed_candidates
+        and not spaced_grid_candidates
+    ):
+        compact_digit_grid_input_format = (
+            _collapse_compact_digit_grid_rows(
+                input_format
+            )
+        )
+
+        if (
+            compact_digit_grid_input_format
+            != input_format
+        ):
+            compact_digit_grid_candidates = (
+                _deduplicate_candidates(
+                    _collect_single_case_candidates(
+                        compact_digit_grid_input_format,
+                        samples,
+                    )
+                )
+            )
+
+    if (
+        len(original_candidates) == 1
+        and len(collapsed_candidates) == 1
+        and _is_structural_string_grid_collapse(
+            original_candidates[0],
+            collapsed_candidates[0],
+            input_format,
+            collapsed_input_format,
+            samples,
+        )
+    ):
+        output_candidates = collapsed_candidates
+
+    elif original_candidates:
+        output_candidates = original_candidates
+
+    elif collapsed_candidates:
+        output_candidates = collapsed_candidates
+
+    elif spaced_grid_candidates:
+        output_candidates = spaced_grid_candidates
+
+    else:
+        output_candidates = (
+            compact_digit_grid_candidates
+        )
 
     if len(output_candidates) > 1:
         raise MultiplePredictionResultsError(

--- a/atcodertools/fmtprediction/predict_format.py
+++ b/atcodertools/fmtprediction/predict_format.py
@@ -205,7 +205,6 @@ def _format_variable_names(format_: Format):
     }
 
 
-
 def _normalized_wrapper_placeholder_name(
     variable_name,
 ):
@@ -346,6 +345,7 @@ def _prefer_explicit_wrapper_candidates(
             for wrapper in wrapper_candidates
         )
     ]
+
 
 def _validate_candidate_on_samples(
     prefix_format: Format,
@@ -1030,7 +1030,6 @@ def predict_multi_case_format(
                             layout,
                         )
                     )
-
 
     valid_predictions = (
         _prefer_explicit_wrapper_candidates(

--- a/atcodertools/fmtprediction/predict_simple_format.py
+++ b/atcodertools/fmtprediction/predict_simple_format.py
@@ -4,7 +4,14 @@ from collections import OrderedDict
 
 from atcodertools.fmtprediction.models.variable import SimpleVariable
 from atcodertools.fmtprediction.models.variable_token import VariableToken
-from atcodertools.fmtprediction.models.format import SingularPattern, Format, ParallelPattern, TwoDimensionalPattern, WrongGroupingError
+from atcodertools.fmtprediction.models.format import (
+    Format,
+    ParallelPattern,
+    SingularPattern,
+    ThreeDimensionalPattern,
+    TwoDimensionalPattern,
+    WrongGroupingError,
+)
 
 
 class UnknownPeriodError(Exception):
@@ -26,33 +33,51 @@ def _predict_period(seq: List[int]):
         return 1
 
 
-def _predict_simple_format_main(var_tokens: List[VariableToken], to_1d_flag=False) -> Format[SimpleVariable]:
+def _predict_simple_format_main(
+    var_tokens: List[VariableToken],
+    to_1d_flag=False,
+) -> Format[SimpleVariable]:
     var_to_positions = {}
     var_to_simple_var = OrderedDict()
 
-    # Pre-computation of the min / max value of each of the first and second
-    # indices.
     for pos, var_token in enumerate(var_tokens):
         var_name = var_token.var_name
 
         if var_name not in var_to_simple_var:
-            var_to_simple_var[var_name] = SimpleVariable.create(
-                var_name, var_token.dim_num())
+            var_to_simple_var[var_name] = (
+                SimpleVariable.create(
+                    var_name,
+                    var_token.dim_num(),
+                )
+            )
             var_to_positions[var_name] = []
 
         var_to_positions[var_name].append(pos)
 
+        if var_token.dim_num() >= 3:
+            var_to_simple_var[
+                var_name
+            ].third_index.update(
+                var_token.third_index
+            )
+
         if var_token.dim_num() >= 2:
-            var_to_simple_var[var_name].second_index.update(
-                var_token.second_index)
+            var_to_simple_var[
+                var_name
+            ].second_index.update(
+                var_token.second_index
+            )
+
         if var_token.dim_num() >= 1:
-            var_to_simple_var[var_name].first_index.update(
-                var_token.first_index)
+            var_to_simple_var[
+                var_name
+            ].first_index.update(
+                var_token.first_index
+            )
 
-    # Building format nodes
     already_processed_vars = set()
+    root = Format()
 
-    root = Format()  # type: Format[SimpleVariable]
     for pos, var_token in enumerate(var_tokens):
         var_name = var_token.var_name
         simple_var = var_to_simple_var[var_name]
@@ -63,32 +88,66 @@ def _predict_simple_format_main(var_tokens: List[VariableToken], to_1d_flag=Fals
         dim = var_token.dim_num()
 
         if dim == 2 and to_1d_flag:
-            simple_var.first_index = simple_var.second_index
+            simple_var.first_index = (
+                simple_var.second_index
+            )
             simple_var.second_index = None
             dim = 1
 
         if dim == 0:
-            root.push_back(SingularPattern(simple_var))
+            root.push_back(
+                SingularPattern(simple_var)
+            )
             already_processed_vars.add(var_name)
+
         elif dim == 1:
-            period = _predict_period(var_to_positions[var_name])
-            parallel_vars_group = [var_to_simple_var[token.var_name]
-                                   for token in var_tokens[pos:pos + period]]
-            try:
-                root.push_back(ParallelPattern(parallel_vars_group))
-            except WrongGroupingError:
-                raise
+            period = _predict_period(
+                var_to_positions[var_name]
+            )
+            parallel_vars_group = [
+                var_to_simple_var[token.var_name]
+                for token in var_tokens[
+                    pos:pos + period
+                ]
+            ]
+
+            root.push_back(
+                ParallelPattern(
+                    parallel_vars_group
+                )
+            )
+
             for var in parallel_vars_group:
-                already_processed_vars.add(var.name)
+                already_processed_vars.add(
+                    var.name
+                )
+
         elif dim == 2:
-            root.push_back(TwoDimensionalPattern(simple_var))
+            root.push_back(
+                TwoDimensionalPattern(
+                    simple_var
+                )
+            )
+            already_processed_vars.add(var_name)
+
+        elif dim == 3:
+            root.push_back(
+                ThreeDimensionalPattern(
+                    simple_var
+                )
+            )
+            already_processed_vars.add(var_name)
+
         else:
             raise NotImplementedError
-        already_processed_vars.add(var_name)
+
     return root
 
 
-def predict_simple_format(var_tokens: List[VariableToken], to_1d_flag=False) -> Format[SimpleVariable]:
+def predict_simple_format(
+    var_tokens: List[VariableToken],
+    to_1d_flag=False,
+) -> Format[SimpleVariable]:
     try:
         return _predict_simple_format_main(var_tokens, to_1d_flag)
     except (WrongGroupingError, UnknownPeriodError):

--- a/atcodertools/fmtprediction/predict_simple_format.py
+++ b/atcodertools/fmtprediction/predict_simple_format.py
@@ -94,6 +94,13 @@ def _predict_simple_format_main(
             simple_var.second_index = None
             dim = 1
 
+        elif dim == 3 and to_1d_flag:
+            # A compact character row represents the innermost
+            # dimension as one string token. Preserve the outer two
+            # indices and collapse only the third dimension.
+            simple_var.third_index = None
+            dim = 2
+
         if dim == 0:
             root.push_back(
                 SingularPattern(simple_var)

--- a/atcodertools/fmtprediction/predict_types.py
+++ b/atcodertools/fmtprediction/predict_types.py
@@ -6,8 +6,13 @@ from atcodertools.fmtprediction.models.type import Type
 from atcodertools.client.models.sample import Sample
 from atcodertools.fmtprediction.models.variable import SimpleVariable
 from atcodertools.fmtprediction.models.index import Index
-from atcodertools.fmtprediction.models.format import Format, SingularPattern, TwoDimensionalPattern, \
-    ParallelPattern
+from atcodertools.fmtprediction.models.format import (
+    Format,
+    ParallelPattern,
+    SingularPattern,
+    ThreeDimensionalPattern,
+    TwoDimensionalPattern,
+)
 from atcodertools.fmtprediction.token_manager import TokenManager
 
 
@@ -139,16 +144,61 @@ class TypePredictor:
 
     def _fetch_generator(self):
         for pattern in self._fmt.sequence:
-            if isinstance(pattern, SingularPattern):
+            if isinstance(
+                pattern,
+                SingularPattern,
+            ):
                 yield pattern.var
-            elif isinstance(pattern, TwoDimensionalPattern):
-                for _ in range(self._loop_size(pattern.var.first_index)):
-                    for _ in range(self._loop_size(pattern.var.second_index)):
+
+            elif isinstance(
+                pattern,
+                TwoDimensionalPattern,
+            ):
+                for _ in range(
+                    self._loop_size(
+                        pattern.var.first_index
+                    )
+                ):
+                    for _ in range(
+                        self._loop_size(
+                            pattern.var.second_index
+                        )
+                    ):
                         yield pattern.var
-            elif isinstance(pattern, ParallelPattern):
-                for _ in range(self._loop_size(pattern.loop_index)):
-                    for v in pattern.vars:
-                        yield v
+
+            elif isinstance(
+                pattern,
+                ThreeDimensionalPattern,
+            ):
+                for _ in range(
+                    self._loop_size(
+                        pattern.var.first_index
+                    )
+                ):
+                    for _ in range(
+                        self._loop_size(
+                            pattern.var.second_index
+                        )
+                    ):
+                        for _ in range(
+                            self._loop_size(
+                                pattern.var.third_index
+                            )
+                        ):
+                            yield pattern.var
+
+            elif isinstance(
+                pattern,
+                ParallelPattern,
+            ):
+                for _ in range(
+                    self._loop_size(
+                        pattern.loop_index
+                    )
+                ):
+                    for var in pattern.vars:
+                        yield var
+
         yield None
         raise TooManyFetchesError()
 
@@ -162,7 +212,10 @@ def merge_type_dicts(to_dict: Dict[str, Type], src_dict: Dict[str, Type]):
     return to_dict
 
 
-def predict_types(simple_format: Format[SimpleVariable], samples: List[Sample]) -> Dict[str, Type]:
+def predict_types(
+    simple_format: Format[SimpleVariable],
+    samples: List[Sample],
+) -> Dict[str, Type]:
     res_type_dict = {}
     for sample in samples:
         token_manager = TokenManager(sample.get_input().split())
@@ -175,8 +228,13 @@ def predict_types(simple_format: Format[SimpleVariable], samples: List[Sample]) 
                 res_type_dict,
                 predictor.get_typing_result())
         except (
-                TooLessFetchesError, TooManyFetchesError, KeyError, InvalidLoopSizeError,
-                InvalidLoopIndexError, EvaluateError):
+                TooLessFetchesError,
+                TooManyFetchesError,
+                KeyError,
+                InvalidLoopSizeError,
+                InvalidLoopIndexError,
+                EvaluateError,
+        ):
             raise TypePredictionFailedError
 
     return res_type_dict

--- a/atcodertools/fmtprediction/tokenize_format.py
+++ b/atcodertools/fmtprediction/tokenize_format.py
@@ -1,8 +1,15 @@
 import copy
+from itertools import combinations
 from typing import List, Dict
 
-from atcodertools.fmtprediction.models.calculator import CalcNode, CalcParseError
-from atcodertools.fmtprediction.models.variable_token import VariableToken, TokenizedFormat
+from atcodertools.fmtprediction.models.calculator import (
+    CalcNode,
+    CalcParseError,
+)
+from atcodertools.fmtprediction.models.variable_token import (
+    VariableToken,
+    TokenizedFormat,
+)
 
 from atcodertools.fmtprediction.token_manager import TokenManager
 
@@ -66,8 +73,16 @@ def _remove_spaces_in_curly_brackets(input_format):
 
 
 def _sanitized_tokens(input_format: str) -> List[str]:
-    input_format = input_format.replace("\n", " ").replace("…", " ").replace("...", " ").replace(
-        "..", " ").replace("\\ ", " ").replace("}", "} ").replace("　", " ").replace(", ", ",")
+    input_format = (
+        input_format.replace("\n", " ")
+        .replace("…", " ")
+        .replace("...", " ")
+        .replace("..", " ")
+        .replace("\\ ", " ")
+        .replace("}", "} ")
+        .replace("　", " ")
+        .replace(", ", ",")
+    )
     input_format = _remove_spaces_in_curly_brackets(input_format)
     input_format = _divide_consecutive_vars(input_format)
     input_format = _normalize_index(input_format)
@@ -102,7 +117,10 @@ class FormatSearcher:
             self._answers.append(TokenizedFormat(copy.deepcopy(var_token_seq)))
             return
 
-        for var_token in self._possible_var_tokens(self._token_manager.peek(), var_to_dim_num):
+        for var_token in self._possible_var_tokens(
+            self._token_manager.peek(),
+            var_to_dim_num,
+        ):
             next_var_to_dim_num = copy.deepcopy(var_to_dim_num)
             next_var_to_dim_num[var_token.var_name] = var_token.dim_num()
             try:
@@ -114,48 +132,143 @@ class FormatSearcher:
                 var_token_seq.pop()
 
     @staticmethod
-    def _possible_var_tokens(token: str, current_var_to_dim_num: Dict[str, int]) -> List[VariableToken]:
+    def _possible_var_tokens(
+        token: str,
+        current_var_to_dim_num: Dict[str, int],
+    ) -> List[VariableToken]:
         """
-        Only considers to divide the given token into at most 3 pieces (that is, to assume at most 2 dimensional indexes).
-        :param token: e.g. "N", "abc_1_2" or "a_1 ... a_N"
-        :param current_var_to_dim_num: utilized to detect unknown variables (for pruning purpose)
-        """
-        var_token_candidates = [VariableToken(token, None, None)]
-        var_token_candidates += [VariableToken(
-            token[:i],
-            token[i:],
-            None) for i in range(1, len(token))]
-        for i in range(1, len(token)):
-            for j in range(i + 1, len(token)):
-                var_token_candidates += [
-                    VariableToken(token[:i], token[i:j], token[j:])]
+        Divide a token into a variable name and up to
+        three index expressions.
 
-        def check_if_possible(var_token: VariableToken):
-            # check syntax error
+        Examples include ``N``, ``a_1``,
+        ``a_1,2`` and ``a_1,2,3``.
+        """
+        candidates = [
+            VariableToken(
+                token,
+                None,
+                None,
+                None,
+            )
+        ]
+
+        for first_split in range(
+            1,
+            len(token),
+        ):
+            candidates.append(
+                VariableToken(
+                    token[:first_split],
+                    token[first_split:],
+                    None,
+                    None,
+                )
+            )
+
+        for first_split in range(
+            1,
+            len(token),
+        ):
+            for second_split in range(
+                first_split + 1,
+                len(token),
+            ):
+                candidates.append(
+                    VariableToken(
+                        token[:first_split],
+                        token[
+                            first_split:second_split
+                        ],
+                        token[second_split:],
+                        None,
+                    )
+                )
+
+        three_dimensional_splits = sorted(
+            {
+                boundary
+                for position, character in enumerate(
+                    token
+                )
+                if character in ("_", ",")
+                for boundary in (
+                    position,
+                    position + 1,
+                )
+                if 0 < boundary < len(token)
+            }
+        )
+
+        for (
+            first_split,
+            second_split,
+            third_split,
+        ) in combinations(
+            three_dimensional_splits,
+            3,
+        ):
+            candidates.append(
+                VariableToken(
+                    token[:first_split],
+                    token[
+                        first_split:second_split
+                    ],
+                    token[
+                        second_split:third_split
+                    ],
+                    token[third_split:],
+                )
+            )
+
+        def check_if_possible(var_token):
             if not var_token.is_valid():
                 return False
 
-            # check kind of synonym error using current_var_to_dim_num
-            for index in [var_token.first_index, var_token.second_index]:
+            for index in (
+                var_token.first_index,
+                var_token.second_index,
+                var_token.third_index,
+            ):
                 if index is None:
                     continue
 
                 try:
-                    for sub_var in CalcNode.parse(index).get_all_variables():
-                        if sub_var not in current_var_to_dim_num:
-                            return False
+                    variables = (
+                        CalcNode.parse(index)
+                        .get_all_variables()
+                    )
                 except CalcParseError:
                     return False
 
-            if var_token.var_name in current_var_to_dim_num \
-                    and current_var_to_dim_num[var_token.var_name] != var_token.dim_num():
+                for sub_var in variables:
+                    if (
+                        sub_var
+                        not in current_var_to_dim_num
+                    ):
+                        return False
+
+            if (
+                var_token.var_name
+                in current_var_to_dim_num
+                and current_var_to_dim_num[
+                    var_token.var_name
+                ]
+                != var_token.dim_num()
+            ):
                 return False
+
             return True
 
-        return [var_token for var_token in var_token_candidates if check_if_possible(var_token)]
+        return [
+            candidate
+            for candidate in candidates
+            if check_if_possible(candidate)
+        ]
 
 
-def search_formats_with_minimum_vars(input_format: str) -> List[TokenizedFormat]:
+def search_formats_with_minimum_vars(
+    input_format: str,
+) -> List[TokenizedFormat]:
     """
     Fast enough for realistic instances.
     This method returns possible formats with the smallest number of variables.

--- a/atcodertools/fmtprediction/tokenize_format.py
+++ b/atcodertools/fmtprediction/tokenize_format.py
@@ -13,6 +13,319 @@ from atcodertools.fmtprediction.models.variable_token import (
 
 from atcodertools.fmtprediction.token_manager import TokenManager
 
+import re
+
+
+_REF = re.compile(r'([A-Za-z]+)(_\{[^{}]*\}|_\([^()]*\)|_[A-Za-z0-9])?')
+
+_DOTS = re.compile(
+    r'[ \t]*(?:\.\.\.\.|\.\.\.|\.\.|…|‥‥|‥|．．．|・・・・|・・・|ldots|cdots|dots)[ \t]*')
+
+_SPACES = re.compile(r'[ \t]+')
+
+_LATEX_DOTS = ["\\ldots", "\\cdots", "\\dots", "\\vdots", "\\ddots"]
+
+_LATEX_SPACES = ["\\,", "\\;", "\\:", "\\!", "\\quad", "\\qquad"]
+
+
+def _normalize_separators(text: str) -> str:
+    """Canonicalize the various ways a separator can be written so that the
+    rest of the pipeline only has to deal with plain spaces (and ``…`` for
+    the sequence indicator)."""
+    for cmd in _LATEX_DOTS:
+        text = text.replace(cmd, "…")
+    for cmd in _LATEX_SPACES:
+        text = text.replace(cmd, " ")
+    # Remaining backslashes are LaTeX line breaks ("\\") / spacing ("\ ") and
+    # carry no information for parsing.
+    text = text.replace("\\", " ")
+    # Full-width space is a regular separator.
+    text = text.replace("　", " ")
+    return text
+
+
+def _strip_last_coord(name: str, idx) -> str:
+    """Drop the trailing coordinate of a variable reference's index.
+
+    c_{1,1} -> c_{1},  c_{11} -> c_{1},  s_{1} -> s,  c_{(0,1)} -> c_{0}
+    """
+    if idx is None:
+        return name
+    body = idx[1:]  # remove leading "_"
+    if ((body.startswith('{') and body.endswith('}'))
+            or (body.startswith('(') and body.endswith(')'))):
+        inner = body[1:-1]
+    else:
+        inner = body
+    if inner.startswith('(') and inner.endswith(')'):
+        inner = inner[1:-1]
+
+    if ',' in inner:
+        coords = inner.split(',')[:-1]
+        if not coords:
+            return name
+        return name + '_{' + ','.join(coords) + '}'
+    if len(inner) <= 1:
+        return name
+    return name + '_{' + inner[:-1] + '}'
+
+
+def _try_collapse_run(line: str, start: int):
+    """Try to match a collapsible run of the same variable starting at start.
+
+    A run is two or more references to the same variable name that are either
+    glued together (no separator) or separated only by dots (a sequence
+    indicator). Returns (collapsed_token, end_index) or None.
+    """
+    m = _REF.match(line, start)
+    if not m or not m.group(1):
+        return None
+    name = m.group(1)
+    first_idx = m.group(2)
+    j = m.end()
+    refs = 1
+    glued = True
+    saw_dots = False
+    while True:
+        k = j
+        sep_has_dots = False
+        sep_has_space = False
+        progressed = True
+        while progressed:
+            progressed = False
+            dm = _DOTS.match(line, k)
+            if dm:
+                sep_has_dots = True
+                k = dm.end()
+                progressed = True
+                continue
+            sm = _SPACES.match(line, k)
+            if sm:
+                sep_has_space = True
+                k = sm.end()
+                progressed = True
+        m2 = _REF.match(line, k)
+        if m2 and m2.group(0) and m2.group(1) == name:
+            if sep_has_space:
+                glued = False
+            if sep_has_dots:
+                saw_dots = True
+            refs += 1
+            j = m2.end()
+        else:
+            break
+
+    if refs >= 2 and (glued or saw_dots):
+        return _strip_last_coord(name, first_idx), j
+    return None
+
+
+_BARE_HEAD = re.compile(r'([A-Za-z])([0-9]+)')
+
+
+def _try_bare_run(line: str, start: int):
+    m = _BARE_HEAD.match(line, start)
+    if not m:
+        return None
+    letter = m.group(1)
+    j = m.end()
+    refs = 1
+    glued = True
+    saw_dots = False
+    esc = re.escape(letter)
+    tail = re.compile(r'(?:' + esc + r'[0-9]+|' + esc + r'[A-Za-z])')
+    while True:
+        k = j
+        sep_has_dots = False
+        sep_has_space = False
+        progressed = True
+        while progressed:
+            progressed = False
+            dm = _DOTS.match(line, k)
+            if dm:
+                sep_has_dots = True
+                k = dm.end()
+                progressed = True
+                continue
+            sm = _SPACES.match(line, k)
+            if sm:
+                sep_has_space = True
+                k = sm.end()
+                progressed = True
+        m2 = tail.match(line, k)
+        if m2:
+            if sep_has_space:
+                glued = False
+            if sep_has_dots:
+                saw_dots = True
+            refs += 1
+            j = m2.end()
+        else:
+            break
+    if refs >= 2 and (glued or saw_dots):
+        return letter, j
+    return None
+
+
+_BARE2D_HEAD = re.compile(
+    r'([A-Za-z])(\([^()]*\)|(?:[0-9]+|[A-Za-z])(?:,(?:[0-9]+|[A-Za-z]))+)')
+
+_BARE2D_TAIL_BODY = \
+    r'(?:\([^()]*\)|(?:[0-9]+|[A-Za-z])(?:,(?:[0-9]+|[A-Za-z]))+)'
+
+
+def _try_bare_2d_run(line: str, start: int):
+    m = _BARE2D_HEAD.match(line, start)
+    if not m:
+        return None
+    letter = m.group(1)
+    first_index = m.group(2)
+    j = m.end()
+    refs = 1
+    glued = True
+    saw_dots = False
+    tail = re.compile(re.escape(letter) + _BARE2D_TAIL_BODY)
+    while True:
+        k = j
+        sep_has_dots = False
+        sep_has_space = False
+        progressed = True
+        while progressed:
+            progressed = False
+            dm = _DOTS.match(line, k)
+            if dm:
+                sep_has_dots = True
+                k = dm.end()
+                progressed = True
+                continue
+            sm = _SPACES.match(line, k)
+            if sm:
+                sep_has_space = True
+                k = sm.end()
+                progressed = True
+        m2 = tail.match(line, k)
+        if m2:
+            if sep_has_space:
+                glued = False
+            if sep_has_dots:
+                saw_dots = True
+            refs += 1
+            j = m2.end()
+        else:
+            break
+    if refs >= 2 and (glued or saw_dots):
+        return _strip_last_coord(letter, '_' + first_index), j
+    return None
+
+
+def _collapse_line(line: str) -> str:
+    out = []
+    i = 0
+    n = len(line)
+    while i < n:
+        collapsed = (_try_collapse_run(line, i)
+                     or _try_bare_2d_run(line, i)
+                     or _try_bare_run(line, i))
+        if collapsed:
+            out.append(collapsed[0])
+            i = collapsed[1]
+        else:
+            out.append(line[i])
+            i += 1
+    return ''.join(out)
+
+
+_ABSTRACT_REF = re.compile(r'[A-Za-z]+_(?:\{([a-z])\}|([a-z]))$')
+
+
+def _abstract_row_indices(line: str):
+    tokens = line.split()
+
+    if not tokens:
+        return None
+
+    indices = []
+
+    for token in tokens:
+        match = _ABSTRACT_REF.fullmatch(
+            token
+        )
+
+        if match is None:
+            return None
+
+        index = (
+            match.group(1)
+            or match.group(2)
+        )
+
+        indices.append(index)
+
+    return indices
+
+
+def _is_abstract_row(
+    line: str,
+    header_variables,
+) -> bool:
+    """Detect a purely illustrative generic row.
+
+    Rows such as ``S_{i}`` are omitted when ``i`` is merely a
+    generic loop index.  A lowercase index declared in the first
+    input-format row, such as ``m`` in ``c_m p_m`` or ``r`` in
+    ``C_r``, is an actual endpoint and must be preserved.
+    """
+    indices = _abstract_row_indices(
+        line
+    )
+
+    if indices is None:
+        return False
+
+    return all(
+        index not in header_variables
+        for index in indices
+    )
+
+
+def collapse_string_runs(
+    input_format: str,
+) -> str:
+    """Collapse character runs while retaining declared endpoints."""
+    input_format = _normalize_separators(
+        input_format
+    )
+
+    source_lines = input_format.split(
+        "\n"
+    )
+
+    header_variables = set()
+
+    if source_lines:
+        header_variables = set(
+            re.findall(
+                r"[A-Za-z][A-Za-z0-9_]*",
+                source_lines[0],
+            )
+        )
+
+    lines = [
+        _collapse_line(line)
+        for line in source_lines
+    ]
+
+    lines = [
+        line
+        for line in lines
+        if not _is_abstract_row(
+            line,
+            header_variables,
+        )
+    ]
+
+    return "\n".join(lines)
+
 
 def _is_ascii(s):
     return all(ord(c) < 128 for c in s)
@@ -73,6 +386,16 @@ def _remove_spaces_in_curly_brackets(input_format):
 
 
 def _sanitized_tokens(input_format: str) -> List[str]:
+    input_format = re.sub(
+        r"(?<=[A-Za-z])'(?=\s|$)",
+        "prime",
+        input_format,
+    )
+    input_format = (
+        input_format
+        .replace("‥‥", "...")
+        .replace("‥", "...")
+    )
     input_format = (
         input_format.replace("\n", " ")
         .replace("…", " ")

--- a/tests/resources/test_fmtprediction/answer.txt
+++ b/tests/resources/test_fmtprediction/answer.txt
@@ -1,5 +1,5 @@
 DEGwer2023-A                             OK                   [(Singular: N),(Singular: K),(Singular: T),(Parallel: A | 1 to K)] [('N', <class 'int'>), ('K', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
-DEGwer2023-B                             No result
+DEGwer2023-B                             OK                   [(Singular: H),(Singular: W),(Singular: textrmmove)] [('H', <class 'int'>), ('W', <class 'int'>), ('textrmmove', <class 'str'>)]
 DEGwer2023-C                             OK                   [(Singular: H),(Singular: W),(Singular: M)] [('H', <class 'int'>), ('W', <class 'int'>), ('M', <class 'int'>)]
 DEGwer2023-D                             OK                   [(Singular: N),(Singular: M),(Singular: X)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>)]
 DEGwer2023-E                             OK                   [(Singular: S)] [('S', <class 'str'>)]
@@ -68,7 +68,7 @@ abc006-C                                 OK                   [(Singular: N),(Si
 abc006-D                                 OK                   [(Singular: N),(Parallel: c | 1 to N)] [('N', <class 'int'>), ('c', <class 'int'>)]
 abc007-A                                 OK                   [(Singular: n)] [('n', <class 'int'>)]
 abc007-B                                 OK                   [(Singular: A)] [('A', <class 'str'>)]
-abc007-C                                 No result
+abc007-C                                 OK                   [(Singular: R),(Singular: C),(Singular: sy),(Singular: sx),(Singular: gy),(Singular: gx),(Parallel: c | 1 to R)] [('R', <class 'int'>), ('C', <class 'int'>), ('sy', <class 'int'>), ('sx', <class 'int'>), ('gy', <class 'int'>), ('gx', <class 'int'>), ('c', <class 'str'>)]
 abc007-D                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
 abc008-A                                 OK                   [(Singular: S),(Singular: T)] [('S', <class 'int'>), ('T', <class 'int'>)]
 abc008-B                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
@@ -119,7 +119,7 @@ abc019-B                                 OK                   [(Singular: s)] [(
 abc019-C                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 abc020-A                                 OK                   [(Singular: Q)] [('Q', <class 'int'>)]
 abc020-B                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
-abc020-C                                 No result
+abc020-C                                 OK                   [(Singular: H),(Singular: W),(Singular: T),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('T', <class 'int'>), ('s', <class 'str'>)]
 abc020-D                                 OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
 abc021-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc021-B                                 OK                   [(Singular: N),(Singular: a),(Singular: b),(Singular: K),(Parallel: P | 1 to K)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('K', <class 'int'>), ('P', <class 'int'>)]
@@ -234,7 +234,7 @@ abc048-B                                 OK                   [(Singular: a),(Si
 abc048-C                                 OK                   [(Singular: N),(Singular: x),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('a', <class 'int'>)]
 abc048-D                                 OK                   [(Singular: s)] [('s', <class 'str'>)]
 abc049-A                                 OK                   [(Singular: c)] [('c', <class 'str'>)]
-abc049-B                                 No result
+abc049-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'str'>)]
 abc049-C                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc049-D                                 OK                   [(Singular: N),(Singular: K),(Singular: L),(Parallel: p,q | 1 to K),(Parallel: r,s | 1 to L)] [('N', <class 'int'>), ('K', <class 'int'>), ('L', <class 'int'>), ('p', <class 'int'>), ('q', <class 'int'>), ('r', <class 'int'>), ('s', <class 'int'>)]
 abc050-A                                 OK                   [(Singular: A),(Singular: op),(Singular: B)] [('A', <class 'int'>), ('op', <class 'str'>), ('B', <class 'int'>)]
@@ -286,7 +286,7 @@ abc061-B                                 OK                   [(Singular: N),(Si
 abc061-C                                 OK                   [(Singular: N),(Singular: K),(Parallel: a,b | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 abc061-D                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b,c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
 abc062-A                                 OK                   [(Singular: x),(Singular: y)] [('x', <class 'int'>), ('y', <class 'int'>)]
-abc062-B                                 No result
+abc062-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 abc062-C                                 OK                   [(Singular: H),(Singular: W)] [('H', <class 'int'>), ('W', <class 'int'>)]
 abc062-D                                 OK                   [(Singular: N),(Parallel: a | 1 to 3*N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 abc063-A                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
@@ -343,9 +343,9 @@ abc075-C                                 OK                   [(Singular: N),(Si
 abc075-D                                 OK                   [(Singular: N),(Singular: K),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 abc076-A                                 OK                   [(Singular: R),(Singular: G)] [('R', <class 'int'>), ('G', <class 'int'>)]
 abc076-B                                 OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
-abc076-C                                 No result
+abc076-C                                 OK                   [(Singular: Sprime),(Singular: T)] [('Sprime', <class 'str'>), ('T', <class 'str'>)]
 abc076-D                                 OK                   [(Singular: N),(Parallel: t | 1 to N),(Parallel: v | 1 to N)] [('N', <class 'int'>), ('t', <class 'int'>), ('v', <class 'int'>)]
-abc077-A                                 No result
+abc077-A                                 OK                   [(Parallel: C | 1 to 2)] [('C', <class 'str'>)]
 abc077-B                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc077-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N),(Parallel: C | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 abc077-D                                 OK                   [(Singular: K)] [('K', <class 'int'>)]
@@ -361,7 +361,7 @@ abc080-A                                 OK                   [(Singular: N),(Si
 abc080-B                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc080-C                                 OK                   [(Singular: N),(ThreeDimensional: F),(TwoDimensional: P)] [('N', <class 'int'>), ('F', <class 'int'>), ('P', <class 'int'>)]
 abc080-D                                 OK                   [(Singular: N),(Singular: C),(Parallel: s,t,c | 1 to N)] [('N', <class 'int'>), ('C', <class 'int'>), ('s', <class 'int'>), ('t', <class 'int'>), ('c', <class 'int'>)]
-abc081-A                                 No result
+abc081-A                                 OK                   [(Singular: s)] [('s', <class 'str'>)]
 abc081-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc081-C                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc081-D                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
@@ -392,7 +392,7 @@ abc087-D                                 OK                   [(Singular: N),(Si
 abc088-A                                 OK                   [(Singular: N),(Singular: A)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc088-B                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 abc088-C                                 OK                   [(TwoDimensional: c)] [('c', <class 'int'>)]
-abc088-D                                 No result
+abc088-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('s', <class 'str'>)]
 abc089-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc089-B                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc089-C                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
@@ -423,7 +423,7 @@ abc095-C                                 OK                   [(Singular: A),(Si
 abc095-D                                 OK                   [(Singular: N),(Singular: C),(Parallel: x,v | 1 to N)] [('N', <class 'int'>), ('C', <class 'int'>), ('x', <class 'int'>), ('v', <class 'int'>)]
 abc096-A                                 OK                   [(Singular: a),(Singular: b)] [('a', <class 'int'>), ('b', <class 'int'>)]
 abc096-B                                 OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: K)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('K', <class 'int'>)]
-abc096-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: s | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('s', <class 'str'>)]
+abc096-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('s', <class 'str'>)]
 abc096-D                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc097-A                                 OK                   [(Singular: a),(Singular: b),(Singular: c),(Singular: d)] [('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('d', <class 'int'>)]
 abc097-B                                 OK                   [(Singular: X)] [('X', <class 'int'>)]
@@ -466,7 +466,7 @@ abc106-B                                 OK                   [(Singular: N)] [(
 abc106-C                                 OK                   [(Singular: S),(Singular: K)] [('S', <class 'int'>), ('K', <class 'int'>)]
 abc106-D                                 OK                   [(Singular: N),(Singular: M),(Singular: Q),(Parallel: L,R | 1 to M),(Parallel: p,q | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('Q', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>), ('p', <class 'int'>), ('q', <class 'int'>)]
 abc107-A                                 OK                   [(Singular: N),(Singular: i)] [('N', <class 'int'>), ('i', <class 'int'>)]
-abc107-B                                 No result
+abc107-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 abc107-C                                 OK                   [(Singular: N),(Singular: K),(Parallel: x | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('x', <class 'int'>)]
 abc107-D                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 abc108-A                                 OK                   [(Singular: K)] [('K', <class 'int'>)]
@@ -630,7 +630,7 @@ abc140-B                                 OK                   [(Singular: N),(Pa
 abc140-C                                 OK                   [(Singular: N),(Parallel: B | 1 to N-1)] [('N', <class 'int'>), ('B', <class 'int'>)]
 abc140-D                                 OK                   [(Singular: N),(Singular: K),(Singular: S)] [('N', <class 'int'>), ('K', <class 'int'>), ('S', <class 'str'>)]
 abc140-E                                 OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
-abc140-F                                 No result
+abc140-F                                 OK                   [(Singular: N),(Parallel: S | 1 to 2^N)] [('N', <class 'int'>), ('S', <class 'int'>)]
 abc141-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc141-B                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc141-C                                 OK                   [(Singular: N),(Singular: K),(Singular: Q),(Parallel: A | 1 to Q)] [('N', <class 'int'>), ('K', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>)]
@@ -694,7 +694,7 @@ abc150-F                                 OK                   [(Singular: N),(Pa
 abc151-A                                 OK                   [(Singular: C)] [('C', <class 'str'>)]
 abc151-B                                 OK                   [(Singular: N),(Singular: K),(Singular: M),(Parallel: A | 1 to N-1)] [('N', <class 'int'>), ('K', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
 abc151-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: p,S | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('p', <class 'int'>), ('S', <class 'str'>)]
-abc151-D                                 No result
+abc151-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc151-E                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc151-F                                 OK                   [(Singular: N),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 abc152-A                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
@@ -743,7 +743,7 @@ abc159-A                                 OK                   [(Singular: N),(Si
 abc159-B                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc159-C                                 OK                   [(Singular: L)] [('L', <class 'int'>)]
 abc159-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-abc159-E                                 No result
+abc159-E                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('S', <class 'str'>)]
 abc159-F                                 OK                   [(Singular: N),(Singular: S),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('S', <class 'int'>), ('A', <class 'int'>)]
 abc160-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc160-B                                 OK                   [(Singular: X)] [('X', <class 'int'>)]
@@ -810,7 +810,7 @@ abc170-B                                 OK                   [(Singular: X),(Si
 abc170-C                                 OK                   [(Singular: X),(Singular: N),(Parallel: p | 1 to N)] [('X', <class 'int'>), ('N', <class 'int'>), ('p', <class 'int'>)]
 abc170-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc170-E                                 OK                   [(Singular: N),(Singular: Q),(Parallel: A,B | 1 to N),(Parallel: C,D | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
-abc170-F                                 No result
+abc170-F                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: x,y | 1 to 2),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('c', <class 'str'>)]
 abc171-A                                 No result
 abc171-B                                 OK                   [(Singular: N),(Singular: K),(Parallel: p | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('p', <class 'int'>)]
 abc171-C                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -825,14 +825,14 @@ abc172-E                                 OK                   [(Singular: N),(Si
 abc172-F                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc173-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc173-B                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
-abc173-C                                 No result
+abc173-C                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('c', <class 'str'>)]
 abc173-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc173-E                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc173-F                                 OK                   [(Singular: N),(Parallel: u,v | 1 to N-1)] [('N', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
 abc174-A                                 OK                   [(Singular: X)] [('X', <class 'int'>)]
 abc174-B                                 OK                   [(Singular: N),(Singular: D),(Parallel: X,Y | 1 to N)] [('N', <class 'int'>), ('D', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 abc174-C                                 OK                   [(Singular: K)] [('K', <class 'int'>)]
-abc174-D                                 No result
+abc174-D                                 OK                   [(Singular: N),(Singular: c)] [('N', <class 'int'>), ('c', <class 'str'>)]
 abc174-E                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc174-F                                 OK                   [(Singular: N),(Singular: Q),(Parallel: c | 1 to N),(Parallel: l,r | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('c', <class 'int'>), ('l', <class 'int'>), ('r', <class 'int'>)]
 abc175-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
@@ -887,13 +887,13 @@ abc183-A                                 OK                   [(Singular: x)] [(
 abc183-B                                 OK                   [(Singular: S_x),(Singular: S_y),(Singular: G_x),(Singular: G_y)] [('S_x', <class 'int'>), ('S_y', <class 'int'>), ('G_x', <class 'int'>), ('G_y', <class 'int'>)]
 abc183-C                                 OK                   [(Singular: N),(Singular: K),(TwoDimensional: T)] [('N', <class 'int'>), ('K', <class 'int'>), ('T', <class 'int'>)]
 abc183-D                                 OK                   [(Singular: N),(Singular: W),(Parallel: S,T,P | 1 to N)] [('N', <class 'int'>), ('W', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>), ('P', <class 'int'>)]
-abc183-E                                 No result
+abc183-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc183-F                                 No result
 abc184-A                                 OK                   [(Singular: a),(Singular: b),(Singular: c),(Singular: d)] [('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('d', <class 'int'>)]
 abc184-B                                 OK                   [(Singular: N),(Singular: X),(Singular: S)] [('N', <class 'int'>), ('X', <class 'int'>), ('S', <class 'str'>)]
 abc184-C                                 OK                   [(Parallel: r,c | 1 to 2)] [('r', <class 'int'>), ('c', <class 'int'>)]
 abc184-D                                 OK                   [(Singular: A),(Singular: B),(Singular: C)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-abc184-E                                 No result
+abc184-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 abc184-F                                 OK                   [(Singular: N),(Singular: T),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
 abc185-A                                 No result
 abc185-B                                 No result
@@ -915,7 +915,7 @@ abc187-E                                 OK                   [(Singular: N),(Pa
 abc187-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc188-A                                 OK                   [(Singular: X),(Singular: Y)] [('X', <class 'int'>), ('Y', <class 'int'>)]
 abc188-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-abc188-C                                 No result
+abc188-C                                 OK                   [(Singular: N),(Parallel: A | 1 to 2^N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc188-D                                 OK                   [(Singular: N),(Singular: C),(Parallel: a,b,c | 1 to N)] [('N', <class 'int'>), ('C', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
 abc188-E                                 No result
 abc188-F                                 OK                   [(Singular: X),(Singular: Y)] [('X', <class 'int'>), ('Y', <class 'int'>)]
@@ -970,7 +970,7 @@ abc196-F                                 OK                   [(Singular: S),(Si
 abc197-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc197-B                                 No result
 abc197-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-abc197-D                                 No result
+abc197-D                                 Multiple results
 abc197-E                                 No result
 abc197-F                                 No result
 abc198-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -1058,7 +1058,7 @@ abc211-D                                 OK                   [(Singular: N),(Si
 abc211-E                                 OK                   [(Singular: N),(Singular: K),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('S', <class 'str'>)]
 abc211-F                                 No result
 abc212-A                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
-abc212-B                                 No result
+abc212-B                                 OK                   [(Singular: X)] [('X', <class 'str'>)]
 abc212-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc212-D                                 No result
 abc212-E                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: U,V | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('U', <class 'int'>), ('V', <class 'int'>)]
@@ -1069,7 +1069,7 @@ abc213-A                                 OK                   [(Singular: A),(Si
 abc213-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc213-C                                 OK                   [(Singular: H),(Singular: W),(Singular: N),(Parallel: A,B | 1 to N)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc213-D                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-abc213-E                                 No result
+abc213-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc213-F                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc213-G                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 abc213-H                                 No result
@@ -1139,7 +1139,7 @@ abc221-G                                 OK                   [(Singular: N),(Si
 abc221-H                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 abc222-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc222-B                                 OK                   [(Singular: N),(Singular: P),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>), ('a', <class 'int'>)]
-abc222-C                                 No result
+abc222-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to 2*N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'str'>)]
 abc222-D                                 OK                   [(Singular: N),(Parallel: a | 1 to N),(Parallel: b | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 abc222-E                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A | 1 to M),(Parallel: U,V | 1 to N-1)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('U', <class 'int'>), ('V', <class 'int'>)]
 abc222-F                                 OK                   [(Singular: N),(Parallel: A,B,C | 1 to N-1),(Parallel: D | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
@@ -1191,7 +1191,7 @@ abc228-C                                 OK                   [(Singular: N),(Si
 abc228-D                                 OK                   [(Singular: Q),(Parallel: t,x | 1 to Q)] [('Q', <class 'int'>), ('t', <class 'int'>), ('x', <class 'int'>)]
 abc228-E                                 OK                   [(Singular: N),(Singular: K),(Singular: M)] [('N', <class 'int'>), ('K', <class 'int'>), ('M', <class 'int'>)]
 abc228-F                                 OK                   [(Singular: H),(Singular: W),(Parallel: h,w | 1 to 2),(TwoDimensional: A)] [('H', <class 'int'>), ('W', <class 'int'>), ('h', <class 'int'>), ('w', <class 'int'>), ('A', <class 'int'>)]
-abc228-G                                 No result
+abc228-G                                 OK                   [(Singular: H),(Singular: W),(Singular: N),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('c', <class 'int'>)]
 abc228-H                                 OK                   [(Singular: N),(Singular: X),(Parallel: A,C | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>), ('C', <class 'int'>)]
 abc229-A                                 OK                   [(Parallel: S | 1 to 2)] [('S', <class 'str'>)]
 abc229-B                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
@@ -1220,7 +1220,7 @@ abc231-H                                 No result
 abc232-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc232-B                                 OK                   [(Singular: S),(Singular: T)] [('S', <class 'str'>), ('T', <class 'str'>)]
 abc232-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to M),(Parallel: C,D | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
-abc232-D                                 No result
+abc232-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'str'>)]
 abc232-E                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: x,y | 1 to 2)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 abc232-F                                 OK                   [(Singular: N),(Singular: X),(Singular: Y),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc232-G                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
@@ -1255,7 +1255,7 @@ abc236-C                                 OK                   [(Singular: N),(Si
 abc236-D                                 No result
 abc236-E                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc236-Ex                                OK                   [(Singular: N),(Singular: M),(Parallel: D | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('D', <class 'int'>)]
-abc236-F                                 No result
+abc236-F                                 OK                   [(Singular: N),(Parallel: c | 1 to 2^N-1)] [('N', <class 'int'>), ('c', <class 'int'>)]
 abc236-G                                 OK                   [(Singular: N),(Singular: T),(Singular: L),(Parallel: u,v | 1 to T)] [('N', <class 'int'>), ('T', <class 'int'>), ('L', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
 abc237-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc237-B                                 OK                   [(Singular: H),(Singular: W),(TwoDimensional: A)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>)]
@@ -1310,7 +1310,7 @@ abc243-B                                 OK                   [(Singular: N),(Pa
 abc243-C                                 OK                   [(Singular: N),(Parallel: X,Y | 1 to N),(Singular: S)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('S', <class 'str'>)]
 abc243-D                                 OK                   [(Singular: N),(Singular: X),(Singular: S)] [('N', <class 'int'>), ('X', <class 'int'>), ('S', <class 'str'>)]
 abc243-E                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-abc243-Ex                                No result
+abc243-Ex                                OK                   [(Singular: H),(Singular: W),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'str'>)]
 abc243-F                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: W | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('W', <class 'int'>)]
 abc243-G                                 No result
 abc244-A                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
@@ -1470,7 +1470,7 @@ abc263-C                                 OK                   [(Singular: N),(Si
 abc263-D                                 OK                   [(Singular: N),(Singular: L),(Singular: R),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>), ('A', <class 'int'>)]
 abc263-E                                 OK                   [(Singular: N),(Parallel: A | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc263-Ex                                OK                   [(Singular: N),(Singular: K),(Parallel: A,B,C | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-abc263-F                                 No result
+abc263-F                                 OK                   [(Singular: N),(TwoDimensional: C)] [('N', <class 'int'>), ('C', <class 'int'>)]
 abc263-G                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc264-A                                 OK                   [(Singular: L),(Singular: R)] [('L', <class 'int'>), ('R', <class 'int'>)]
 abc264-B                                 OK                   [(Singular: R),(Singular: C)] [('R', <class 'int'>), ('C', <class 'int'>)]
@@ -1482,7 +1482,7 @@ abc264-F                                 No result
 abc264-G                                 OK                   [(Singular: N),(Parallel: T,P | 1 to N)] [('N', <class 'int'>), ('T', <class 'str'>), ('P', <class 'int'>)]
 abc265-A                                 OK                   [(Singular: X),(Singular: Y),(Singular: N)] [('X', <class 'int'>), ('Y', <class 'int'>), ('N', <class 'int'>)]
 abc265-B                                 OK                   [(Singular: N),(Singular: M),(Singular: T),(Parallel: A | 1 to N-1),(Parallel: X,Y | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
-abc265-C                                 No result
+abc265-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: G | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('G', <class 'str'>)]
 abc265-D                                 OK                   [(Singular: N),(Singular: P),(Singular: Q),(Singular: R),(Parallel: A | 0 to N-1)] [('N', <class 'int'>), ('P', <class 'int'>), ('Q', <class 'int'>), ('R', <class 'int'>), ('A', <class 'int'>)]
 abc265-E                                 OK                   [(Singular: N),(Singular: M),(Singular: A),(Singular: B),(Singular: C),(Singular: D),(Singular: E),(Singular: F),(Parallel: X,Y | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>), ('E', <class 'int'>), ('F', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 abc265-Ex                                OK                   [(Singular: H),(Singular: W)] [('H', <class 'int'>), ('W', <class 'int'>)]
@@ -1534,7 +1534,7 @@ abc271-D                                 OK                   [(Singular: N),(Si
 abc271-E                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A,B,C | 1 to M),(Parallel: E | 1 to K)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('E', <class 'int'>)]
 abc271-Ex                                No result
 abc271-F                                 OK                   [(Singular: N),(TwoDimensional: a)] [('N', <class 'int'>), ('a', <class 'int'>)]
-abc271-G                                 No result
+abc271-G                                 OK                   [(Singular: N),(Singular: X),(Singular: Y),(Singular: c)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('c', <class 'str'>)]
 abc272-A                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc272-B                                 No result
 abc272-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
@@ -1552,13 +1552,13 @@ abc273-Ex                                OK                   [(Singular: N),(Pa
 abc273-F                                 OK                   [(Singular: N),(Singular: X),(Parallel: Y | 1 to N),(Parallel: Z | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('Z', <class 'int'>)]
 abc273-G                                 OK                   [(Singular: N),(Parallel: R | 1 to N),(Parallel: C | 1 to N)] [('N', <class 'int'>), ('R', <class 'int'>), ('C', <class 'int'>)]
 abc274-A                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
-abc274-B                                 No result
+abc274-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'str'>)]
 abc274-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc274-D                                 OK                   [(Singular: N),(Singular: x),(Singular: y),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('A', <class 'int'>)]
 abc274-E                                 OK                   [(Singular: N),(Singular: M),(Parallel: X,Y | 1 to N),(Parallel: P,Q | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('P', <class 'int'>), ('Q', <class 'int'>)]
 abc274-Ex                                No result
 abc274-F                                 OK                   [(Singular: N),(Singular: A),(Parallel: W,X,V | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('W', <class 'int'>), ('X', <class 'int'>), ('V', <class 'int'>)]
-abc274-G                                 No result
+abc274-G                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc275-A                                 OK                   [(Singular: N),(Parallel: H | 1 to N)] [('N', <class 'int'>), ('H', <class 'int'>)]
 abc275-B                                 OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: D),(Singular: E),(Singular: F)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>), ('E', <class 'int'>), ('F', <class 'int'>)]
 abc275-C                                 OK                   [(Parallel: S | 1 to 9)] [('S', <class 'str'>)]
@@ -1571,7 +1571,7 @@ abc276-A                                 OK                   [(Singular: S)] [(
 abc276-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc276-C                                 OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
 abc276-D                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
-abc276-E                                 No result
+abc276-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'str'>)]
 abc276-Ex                                OK                   [(Singular: N),(Singular: Q),(Parallel: a,b,c,d,e | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('d', <class 'int'>), ('e', <class 'int'>)]
 abc276-F                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc276-G                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
@@ -1646,7 +1646,7 @@ abc285-D                                 OK                   [(Singular: N),(Pa
 abc285-E                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc285-Ex                                OK                   [(Singular: N),(Singular: K),(Parallel: E | 1 to K)] [('N', <class 'int'>), ('K', <class 'int'>), ('E', <class 'int'>)]
 abc285-F                                 No result
-abc285-G                                 No result
+abc285-G                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 abc286-A                                 OK                   [(Singular: N),(Singular: P),(Singular: Q),(Singular: R),(Singular: S),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>), ('Q', <class 'int'>), ('R', <class 'int'>), ('S', <class 'int'>), ('A', <class 'int'>)]
 abc286-B                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc286-C                                 OK                   [(Singular: N),(Singular: A),(Singular: B),(Singular: S)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('S', <class 'str'>)]
@@ -1669,7 +1669,7 @@ abc288-D                                 OK                   [(Singular: N),(Si
 abc288-E                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: C | 1 to N),(Parallel: X | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('C', <class 'int'>), ('X', <class 'int'>)]
 abc288-Ex                                OK                   [(Singular: N),(Singular: M),(Singular: X)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>)]
 abc288-F                                 OK                   [(Singular: N),(Singular: X)] [('N', <class 'int'>), ('X', <class 'int'>)]
-abc288-G                                 No result
+abc288-G                                 OK                   [(Singular: N),(Parallel: A | 0 to 3^N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc289-A                                 OK                   [(Singular: s)] [('s', <class 'str'>)]
 abc289-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: a | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>)]
 abc289-C                                 No result
@@ -1719,11 +1719,11 @@ abc294-Ex                                OK                   [(Singular: N),(Si
 abc294-F                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A,B | 1 to N),(Parallel: C,D | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 abc294-G                                 No result
 abc295-A                                 OK                   [(Singular: N),(Parallel: W | 1 to N)] [('N', <class 'int'>), ('W', <class 'str'>)]
-abc295-B                                 No result
+abc295-B                                 OK                   [(Singular: R),(Singular: C),(Parallel: B | 1 to R)] [('R', <class 'int'>), ('C', <class 'int'>), ('B', <class 'str'>)]
 abc295-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc295-D                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc295-E                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
-abc295-Ex                                No result
+abc295-Ex                                OK                   [(Singular: N),(Singular: M),(Parallel: X | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'str'>)]
 abc295-F                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: S),(Singular: L),(Singular: R)]] [('T', <class 'int'>)]
 abc295-G                                 No result
 abc296-A                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
@@ -1758,7 +1758,7 @@ abc299-Ex                                OK                   [(Singular: R)] [(
 abc299-F                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc299-G                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
 abc300-A                                 OK                   [(Singular: N),(Singular: A),(Singular: B),(Parallel: C | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-abc300-B                                 No result
+abc300-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H),(Parallel: B | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>), ('B', <class 'str'>)]
 abc300-C                                 No result
 abc300-D                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc300-E                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -1769,7 +1769,7 @@ abc301-A                                 OK                   [(Singular: N),(Si
 abc301-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc301-C                                 OK                   [(Singular: S),(Singular: T)] [('S', <class 'str'>), ('T', <class 'str'>)]
 abc301-D                                 OK                   [(Singular: S),(Singular: N)] [('S', <class 'str'>), ('N', <class 'int'>)]
-abc301-E                                 No result
+abc301-E                                 OK                   [(Singular: H),(Singular: W),(Singular: T),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('T', <class 'int'>), ('A', <class 'str'>)]
 abc301-Ex                                OK                   [(Singular: N),(Singular: M),(Parallel: U,V,W | 1 to M),(Singular: Q),(Parallel: A,S,T | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('U', <class 'int'>), ('V', <class 'int'>), ('W', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>)]
 abc301-F                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc301-G                                 OK                   [(Singular: N),(Parallel: X,Y,Z | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('Z', <class 'int'>)]
@@ -1799,7 +1799,7 @@ abc304-F                                 OK                   [(Singular: N),(Si
 abc304-G                                 OK                   [(Singular: N),(Parallel: A | 1 to 2*N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc305-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc305-B                                 OK                   [(Singular: p),(Singular: q)] [('p', <class 'str'>), ('q', <class 'str'>)]
-abc305-C                                 No result
+abc305-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc305-D                                 No result
 abc305-E                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: a,b | 1 to M),(Parallel: p,h | 1 to K)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('p', <class 'int'>), ('h', <class 'int'>)]
 abc305-Ex                                OK                   [(Singular: N),(Singular: X),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
@@ -1879,7 +1879,7 @@ abc314-G                                 OK                   [(Singular: N),(Si
 abc315-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc315-B                                 OK                   [(Singular: M),(Parallel: D | 1 to M)] [('M', <class 'int'>), ('D', <class 'int'>)]
 abc315-C                                 OK                   [(Singular: N),(Parallel: F,S | 1 to N)] [('N', <class 'int'>), ('F', <class 'int'>), ('S', <class 'int'>)]
-abc315-D                                 No result
+abc315-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 abc315-E                                 No result
 abc315-Ex                                OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc315-F                                 OK                   [(Singular: N),(Parallel: X,Y | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
@@ -1888,7 +1888,7 @@ abc317-A                                 OK                   [(Singular: N),(Si
 abc317-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc317-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 abc317-D                                 OK                   [(Singular: N),(Parallel: X,Y,Z | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('Z', <class 'int'>)]
-abc317-E                                 No result
+abc317-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>)]
 abc317-Ex                                OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N),(Parallel: B | 1 to N),(Parallel: C | 1 to N),(Parallel: D | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 abc317-F                                 OK                   [(Singular: N),(Parallel: A | 1 to 3)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc317-G                                 OK                   [(Singular: N),(Singular: M),(TwoDimensional: A)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
@@ -1924,7 +1924,7 @@ abc321-G                                 OK                   [(Singular: N),(Si
 abc322-A                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc322-B                                 OK                   [(Singular: N),(Singular: M),(Singular: S),(Singular: T)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'str'>), ('T', <class 'str'>)]
 abc322-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
-abc322-D                                 No result
+abc322-D                                 OK                   [(TwoDimensional: P)] [('P', <class 'str'>)]
 abc322-E                                 No result
 abc322-F                                 No result
 abc322-G                                 OK                   [(Singular: N),(Singular: X)] [('N', <class 'int'>), ('X', <class 'int'>)]
@@ -1937,7 +1937,7 @@ abc323-F                                 OK                   [(Singular: X_A),(
 abc323-G                                 OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
 abc324-A                                 No result
 abc324-B                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
-abc324-C                                 No result
+abc324-C                                 OK                   [(Singular: N),(Singular: Tprime),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('Tprime', <class 'str'>), ('S', <class 'str'>)]
 abc324-D                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc324-E                                 OK                   [(Singular: N),(Singular: T),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('T', <class 'str'>), ('S', <class 'str'>)]
 abc324-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: u,v,b,c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
@@ -1999,7 +1999,7 @@ abc332-E                                 OK                   [(Singular: N),(Si
 abc332-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: L,R,X | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>), ('X', <class 'int'>)]
 abc332-G                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc333-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
-abc333-B                                 No result
+abc333-B                                 OK                   [(Singular: S),(Singular: T)] [('S', <class 'str'>), ('T', <class 'str'>)]
 abc333-C                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc333-D                                 No result
 abc333-E                                 No result
@@ -2009,9 +2009,9 @@ abc334-A                                 OK                   [(Singular: B),(Si
 abc334-B                                 OK                   [(Singular: A),(Singular: M),(Singular: L),(Singular: R)] [('A', <class 'int'>), ('M', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 abc334-C                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to K)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc334-D                                 No result
-abc334-E                                 No result
+abc334-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc334-F                                 OK                   [(Singular: N),(Singular: K),(Singular: S_X),(Singular: S_Y),(Parallel: X,Y | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('S_X', <class 'int'>), ('S_Y', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
-abc334-G                                 No result
+abc334-G                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc335-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc335-B                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc335-C                                 No result
@@ -2106,7 +2106,7 @@ abc347-G                                 No result
 abc348-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc348-B                                 OK                   [(Singular: N),(Parallel: X,Y | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 abc348-C                                 OK                   [(Singular: N),(Parallel: A,C | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('C', <class 'int'>)]
-abc348-D                                 No result
+abc348-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H),(Singular: N),(Parallel: R,C,E | 1 to N)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>), ('N', <class 'int'>), ('R', <class 'int'>), ('C', <class 'int'>), ('E', <class 'int'>)]
 abc348-E                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N-1),(Parallel: C | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 abc348-F                                 OK                   [(Singular: N),(Singular: M),(TwoDimensional: A)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
 abc348-G                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
@@ -2231,7 +2231,7 @@ abc365-G                                 No result
 abc366-A                                 OK                   [(Singular: N),(Singular: T),(Singular: A)] [('N', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
 abc366-B                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc366-C                                 No result
-abc366-D                                 No result
+abc366-D                                 OK                   [(Singular: N),(ThreeDimensional: A),(Singular: Q),(Parallel: Lx,Rx,Ly,Ry,Lz,Rz | 1 to Q)] [('N', <class 'int'>), ('A', <class 'int'>), ('Q', <class 'int'>), ('Lx', <class 'int'>), ('Rx', <class 'int'>), ('Ly', <class 'int'>), ('Ry', <class 'int'>), ('Lz', <class 'int'>), ('Rz', <class 'int'>)]
 abc366-E                                 OK                   [(Singular: N),(Singular: D),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('D', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 abc366-F                                 OK                   [(Singular: N),(Singular: K),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc366-G                                 OK                   [(Singular: N),(Singular: M),(Parallel: u,v | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
@@ -2263,7 +2263,7 @@ abc370-D                                 OK                   [(Singular: H),(Si
 abc370-E                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc370-F                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc370-G                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
-abc371-A                                 No result
+abc371-A                                 OK                   [(Singular: S_mathrmAB),(Singular: S_mathrmAC),(Singular: S_mathrmBC)] [('S_mathrmAB', <class 'str'>), ('S_mathrmAC', <class 'str'>), ('S_mathrmBC', <class 'str'>)]
 abc371-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'str'>)]
 abc371-C                                 No result
 abc371-D                                 OK                   [(Singular: N),(Parallel: X | 1 to N),(Parallel: P | 1 to N),(Singular: Q),(Parallel: L,R | 1 to Q)] [('N', <class 'int'>), ('X', <class 'int'>), ('P', <class 'int'>), ('Q', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
@@ -2293,7 +2293,7 @@ abc374-F                                 OK                   [(Singular: N),(Si
 abc374-G                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc375-A                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc375-B                                 OK                   [(Singular: N),(Parallel: X,Y | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
-abc375-C                                 No result
+abc375-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'str'>)]
 abc375-D                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc375-E                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc375-F                                 No result
@@ -2315,7 +2315,7 @@ abc377-G                                 OK                   [(Singular: N),(Pa
 abc378-A                                 OK                   [(Parallel: A | 1 to 4)] [('A', <class 'int'>)]
 abc378-B                                 OK                   [(Singular: N),(Parallel: q,r | 1 to N),(Singular: Q),(Parallel: t,d | 1 to Q)] [('N', <class 'int'>), ('q', <class 'int'>), ('r', <class 'int'>), ('Q', <class 'int'>), ('t', <class 'int'>), ('d', <class 'int'>)]
 abc378-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-abc378-D                                 No result
+abc378-D                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('S', <class 'str'>)]
 abc378-E                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
 abc378-F                                 OK                   [(Singular: N),(Parallel: u,v | 1 to N-1)] [('N', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
 abc378-G                                 OK                   [(Singular: A),(Singular: B),(Singular: M)] [('A', <class 'int'>), ('B', <class 'int'>), ('M', <class 'int'>)]
@@ -2325,7 +2325,7 @@ abc379-C                                 OK                   [(Singular: N),(Si
 abc379-D                                 No result
 abc379-E                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc379-F                                 OK                   [(Singular: N),(Singular: Q),(Parallel: H | 1 to N),(Parallel: l,r | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('H', <class 'int'>), ('l', <class 'int'>), ('r', <class 'int'>)]
-abc379-G                                 No result
+abc379-G                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc380-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc380-B                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc380-C                                 OK                   [(Singular: N),(Singular: K),(Singular: S)] [('N', <class 'int'>), ('K', <class 'int'>), ('S', <class 'str'>)]
@@ -2348,8 +2348,8 @@ abc382-E                                 OK                   [(Singular: N),(Si
 abc382-F                                 OK                   [(Singular: H),(Singular: W),(Singular: N),(Parallel: R,C,L | 1 to N)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('R', <class 'int'>), ('C', <class 'int'>), ('L', <class 'int'>)]
 abc382-G                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: K),(Singular: S_x),(Singular: S_y),(Singular: T_x),(Singular: T_y)]] [('T', <class 'int'>)]
 abc383-A                                 OK                   [(Singular: N),(Parallel: T,V | 1 to N)] [('N', <class 'int'>), ('T', <class 'int'>), ('V', <class 'int'>)]
-abc383-B                                 No result
-abc383-C                                 No result
+abc383-B                                 OK                   [(Singular: H),(Singular: W),(Singular: D),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('D', <class 'int'>), ('S', <class 'str'>)]
+abc383-C                                 OK                   [(Singular: H),(Singular: W),(Singular: D),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('D', <class 'int'>), ('S', <class 'str'>)]
 abc383-D                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc383-E                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: u,v,w | 1 to M),(Parallel: A | 1 to K),(Parallel: B | 1 to K)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>), ('w', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc383-F                                 OK                   [(Singular: N),(Singular: X),(Singular: K),(Parallel: P,U,C | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('K', <class 'int'>), ('P', <class 'int'>), ('U', <class 'int'>), ('C', <class 'int'>)]
@@ -2362,7 +2362,7 @@ abc384-E                                 No result
 abc384-F                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc384-G                                 OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N),(Singular: K),(Parallel: X,Y | 1 to K)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('K', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 abc385-A                                 OK                   [(Singular: A),(Singular: B),(Singular: C)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-abc385-B                                 No result
+abc385-B                                 OK                   [(Singular: H),(Singular: W),(Singular: X),(Singular: Y),(Parallel: S | 1 to H),(Singular: T)] [('H', <class 'int'>), ('W', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('S', <class 'str'>), ('T', <class 'str'>)]
 abc385-C                                 OK                   [(Singular: N),(Parallel: H | 1 to N)] [('N', <class 'int'>), ('H', <class 'int'>)]
 abc385-D                                 OK                   [(Singular: N),(Singular: M),(Singular: S_x),(Singular: S_y),(Parallel: X,Y | 1 to N),(Parallel: D,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('S_x', <class 'int'>), ('S_y', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('D', <class 'str'>), ('C', <class 'int'>)]
 abc385-E                                 OK                   [(Singular: N),(Parallel: u,v | 1 to N-1)] [('N', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
@@ -2407,7 +2407,7 @@ abc391-A                                 OK                   [(Singular: D)] [(
 abc391-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: S | 1 to N),(Parallel: T | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'str'>), ('T', <class 'str'>)]
 abc391-C                                 No result
 abc391-D                                 OK                   [(Singular: N),(Singular: W),(Parallel: X,Y | 1 to N),(Singular: Q),(Parallel: T,A | 1 to Q)] [('N', <class 'int'>), ('W', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('Q', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
-abc391-E                                 No result
+abc391-E                                 OK                   [(Singular: N),(Singular: A)] [('N', <class 'int'>), ('A', <class 'str'>)]
 abc391-F                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N),(Parallel: B | 1 to N),(Parallel: C | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 abc391-G                                 OK                   [(Singular: N),(Singular: M),(Singular: S)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'str'>)]
 abc392-A                                 OK                   [(Parallel: A | 1 to 3)] [('A', <class 'int'>)]
@@ -2428,7 +2428,7 @@ abc394-A                                 OK                   [(Singular: S)] [(
 abc394-B                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc394-C                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc394-D                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
-abc394-E                                 No result
+abc394-E                                 OK                   [(Singular: N),(Parallel: C | 1 to N)] [('N', <class 'int'>), ('C', <class 'str'>)]
 abc394-F                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc394-G                                 OK                   [(Singular: H),(Singular: W),(TwoDimensional: F),(Singular: Q),(Parallel: A,B,Y,C,D,Z | 1 to Q)] [('H', <class 'int'>), ('W', <class 'int'>), ('F', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('Y', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>), ('Z', <class 'int'>)]
 abc395-A                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
@@ -2444,7 +2444,7 @@ abc396-C                                 OK                   [(Singular: N),(Si
 abc396-D                                 OK                   [(Singular: N),(Singular: M),(Parallel: u,v,w | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>), ('w', <class 'int'>)]
 abc396-E                                 OK                   [(Singular: N),(Singular: M),(Parallel: X,Y,Z | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('Z', <class 'int'>)]
 abc396-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
-abc396-G                                 No result
+abc396-G                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>)]
 abc397-A                                 OK                   [(Singular: X)] [('X', <class 'float'>)]
 abc397-B                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc397-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
@@ -2504,7 +2504,7 @@ abc404-G                                 OK                   [(Singular: N),(Si
 abc405-A                                 OK                   [(Singular: R),(Singular: X)] [('R', <class 'int'>), ('X', <class 'int'>)]
 abc405-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
 abc405-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-abc405-D                                 No result
+abc405-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc405-E                                 OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: D)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 abc405-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to M),(Singular: Q),(Parallel: C,D | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('Q', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 abc405-G                                 No result
@@ -2609,7 +2609,7 @@ abc419-G                                 OK                   [(Singular: N),(Si
 abc420-A                                 OK                   [(Singular: X),(Singular: Y)] [('X', <class 'int'>), ('Y', <class 'int'>)]
 abc420-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'str'>)]
 abc420-C                                 OK                   [(Singular: N),(Singular: Q),(Parallel: A | 1 to N),(Parallel: B | 1 to N),(Parallel: c,X,V | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('c', <class 'str'>), ('X', <class 'int'>), ('V', <class 'int'>)]
-abc420-D                                 No result
+abc420-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>)]
 abc420-E                                 No result
 abc420-F                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('S', <class 'str'>)]
 abc420-G                                 OK                   [(Singular: X)] [('X', <class 'int'>)]
@@ -2644,7 +2644,7 @@ abc424-G                                 OK                   [(Singular: N),(Si
 abc425-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc425-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc425-C                                 No result
-abc425-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+abc425-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc425-E                                 No result
 abc425-F                                 OK                   [(Singular: N),(Singular: T)] [('N', <class 'int'>), ('T', <class 'str'>)]
 abc425-G                                 OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
@@ -2721,7 +2721,7 @@ abc435-G                                 OK                   [(Singular: N),(Si
 abc436-A                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc436-B                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc436-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: R,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('R', <class 'int'>), ('C', <class 'int'>)]
-abc436-D                                 No result
+abc436-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc436-E                                 No result
 abc436-F                                 No result
 abc436-G                                 No result
@@ -2752,7 +2752,7 @@ abc440-C                                 OK                   [RepeatedCase: pre
 abc440-D                                 OK                   [(Singular: N),(Singular: Q),(Parallel: A | 1 to N),(Parallel: X,Y | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 abc440-E                                 OK                   [(Singular: N),(Singular: K),(Singular: X),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>)]
 abc440-F                                 OK                   [(Singular: N),(Singular: Q),(Parallel: A,B | 1 to N),(Parallel: W,X,Y | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('W', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
-abc440-G                                 No result
+abc440-G                                 OK                   [(Singular: F),(Singular: H),(Singular: W),(TwoDimensional: S),(Singular: Q),(Parallel: G,A,B | 1 to Q)] [('F', <class 'int'>), ('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>), ('Q', <class 'int'>), ('G', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc441-A                                 OK                   [(Singular: P),(Singular: Q),(Singular: X),(Singular: Y)] [('P', <class 'int'>), ('Q', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 abc441-B                                 No result
 abc441-C                                 OK                   [(Singular: N),(Singular: K),(Singular: X),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>)]
@@ -2779,7 +2779,7 @@ abc444-B                                 OK                   [(Singular: N),(Si
 abc444-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc444-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 abc444-E                                 OK                   [(Singular: N),(Singular: D),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('D', <class 'int'>), ('A', <class 'int'>)]
-abc444-F                                 Multiple results
+abc444-F                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: M),(Parallel: A | 1 to N)]] [('T', <class 'int'>)]
 abc444-G                                 OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: M),(Parallel: P,E | 1 to M)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('M', <class 'int'>), ('P', <class 'int'>), ('E', <class 'int'>)]
 abc445-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 abc445-B                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
@@ -2818,7 +2818,7 @@ abc449-F                                 OK                   [(Singular: H),(Si
 abc449-G                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 abc450-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 abc450-B                                 No result
-abc450-C                                 No result
+abc450-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc450-D                                 OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 abc450-E                                 OK                   [(Singular: X),(Singular: Y),(Singular: Q),(Parallel: L,R,C | 1 to Q)] [('X', <class 'str'>), ('Y', <class 'str'>), ('Q', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>), ('C', <class 'str'>)]
 abc450-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: X,Y | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
@@ -2840,7 +2840,7 @@ abc452-G                                 OK                   [(Singular: N),(Pa
 abc453-A                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 abc453-B                                 OK                   [(Singular: T),(Singular: X),(Parallel: A | 0 to T)] [('T', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>)]
 abc453-C                                 OK                   [(Singular: N),(Parallel: L | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>)]
-abc453-D                                 No result
+abc453-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 abc453-E                                 OK                   [(Singular: N),(Parallel: L,R | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 abc453-F                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: K),(Parallel: U,V | 1 to N-1),(Parallel: C | 1 to K)]] [('T', <class 'int'>)]
 abc453-G                                 No result
@@ -2915,7 +2915,7 @@ abc463-E                                 No result
 abc463-F                                 No result
 abc463-G                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: X)]] [('T', <class 'int'>)]
 abc464-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
-abc464-B                                 No result
+abc464-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'str'>)]
 abc464-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,D,B | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('D', <class 'int'>), ('B', <class 'int'>)]
 abc464-D                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: S),(Parallel: X | 1 to N),(Parallel: Y | 1 to N-1)]] [('T', <class 'int'>)]
 abc464-E                                 OK                   [(Singular: H),(Singular: W),(Singular: Q),(Parallel: R,C,X | 1 to Q)] [('H', <class 'int'>), ('W', <class 'int'>), ('Q', <class 'int'>), ('R', <class 'int'>), ('C', <class 'int'>), ('X', <class 'str'>)]
@@ -2964,12 +2964,12 @@ agc003-B                                 OK                   [(Singular: N),(Pa
 agc003-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 agc003-D                                 OK                   [(Singular: N),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('s', <class 'int'>)]
 agc003-E                                 OK                   [(Singular: N),(Singular: Q),(Parallel: q | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('q', <class 'int'>)]
-agc003-F                                 No result
+agc003-F                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('s', <class 'str'>)]
 agc004-A                                 OK                   [(Singular: A),(Singular: B),(Singular: C)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 agc004-B                                 OK                   [(Singular: N),(Singular: x),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('a', <class 'int'>)]
-agc004-C                                 No result
+agc004-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 agc004-D                                 OK                   [(Singular: N),(Singular: K),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>)]
-agc004-E                                 No result
+agc004-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 agc004-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 agc005-A                                 OK                   [(Singular: X)] [('X', <class 'str'>)]
 agc005-B                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
@@ -2983,7 +2983,7 @@ agc006-C                                 OK                   [(Singular: N),(Pa
 agc006-D                                 OK                   [(Singular: N),(Parallel: a | 1 to 2*N-1)] [('N', <class 'int'>), ('a', <class 'int'>)]
 agc006-E                                 OK                   [(Singular: N),(TwoDimensional: a)] [('N', <class 'int'>), ('a', <class 'int'>)]
 agc006-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
-agc007-A                                 No result
+agc007-A                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>)]
 agc007-B                                 OK                   [(Singular: N),(Parallel: p | 1 to N)] [('N', <class 'int'>), ('p', <class 'int'>)]
 agc007-C                                 OK                   [(Singular: N),(Parallel: d | 1 to 1),(Singular: x)] [('N', <class 'int'>), ('d', <class 'int'>), ('x', <class 'int'>)]
 agc007-D                                 OK                   [(Singular: N),(Singular: E),(Singular: T),(Parallel: x | 1 to N)] [('N', <class 'int'>), ('E', <class 'int'>), ('T', <class 'int'>), ('x', <class 'int'>)]
@@ -3026,12 +3026,12 @@ agc013-E                                 OK                   [(Singular: N),(Si
 agc013-F                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N),(Parallel: C | 1 to N+1),(Singular: Q),(Parallel: D,E | 1 to Q)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('Q', <class 'int'>), ('D', <class 'int'>), ('E', <class 'int'>)]
 agc014-A                                 OK                   [(Singular: A),(Singular: B),(Singular: C)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 agc014-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
-agc014-C                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: A | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('A', <class 'str'>)]
+agc014-C                                 OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('A', <class 'str'>)]
 agc014-D                                 OK                   [(Singular: N),(Parallel: a,b | 1 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 agc014-E                                 OK                   [(Singular: N),(Parallel: a,b | 1 to N-1),(Parallel: c,d | 1 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('d', <class 'int'>)]
 agc014-F                                 OK                   [(Singular: N),(Parallel: p | 1 to N)] [('N', <class 'int'>), ('p', <class 'int'>)]
 agc015-A                                 OK                   [(Singular: N),(Singular: A),(Singular: B)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-agc015-B                                 No result
+agc015-B                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 agc015-C                                 No result
 agc015-D                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
 agc015-E                                 OK                   [(Singular: N),(Parallel: X,V | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('V', <class 'int'>)]
@@ -3142,7 +3142,7 @@ agc032-F                                 OK                   [(Singular: N)] [(
 agc033-A                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>)]
 agc033-B                                 OK                   [(Singular: H),(Singular: W),(Singular: N),(Singular: s_r),(Singular: s_c),(Singular: S),(Singular: T)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('s_r', <class 'int'>), ('s_c', <class 'int'>), ('S', <class 'str'>), ('T', <class 'str'>)]
 agc033-C                                 OK                   [(Singular: N),(Parallel: a,b | 1 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
-agc033-D                                 No result
+agc033-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>)]
 agc033-E                                 OK                   [(Singular: N),(Singular: M),(Singular: S)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'str'>)]
 agc033-F                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to N-1),(Parallel: c,d | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('d', <class 'int'>)]
 agc034-A                                 OK                   [(Singular: N),(Singular: A),(Singular: B),(Singular: C),(Singular: D),(Singular: S)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>), ('S', <class 'str'>)]
@@ -3150,7 +3150,7 @@ agc034-B                                 OK                   [(Singular: s)] [(
 agc034-C                                 OK                   [(Singular: N),(Singular: X),(Parallel: b,l,u | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('b', <class 'int'>), ('l', <class 'int'>), ('u', <class 'int'>)]
 agc034-D                                 OK                   [(Singular: N),(Parallel: RX,RY,RC | 1 to N),(Parallel: BX,BY,BC | 1 to N)] [('N', <class 'int'>), ('RX', <class 'int'>), ('RY', <class 'int'>), ('RC', <class 'int'>), ('BX', <class 'int'>), ('BY', <class 'int'>), ('BC', <class 'int'>)]
 agc034-E                                 OK                   [(Singular: N),(Singular: S),(Parallel: a,b | 1 to N-1)] [('N', <class 'int'>), ('S', <class 'str'>), ('a', <class 'int'>), ('b', <class 'int'>)]
-agc034-F                                 No result
+agc034-F                                 OK                   [(Singular: N),(Parallel: A | 0 to 2^N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
 agc035-A                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 agc035-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 agc035-C                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -3197,10 +3197,10 @@ agc043-A                                 OK                   [(Singular: H),(Si
 agc043-B                                 OK                   [(Singular: N),(Parallel: a | 1 to 1)] [('N', <class 'int'>), ('a', <class 'int'>)]
 agc043-C                                 No result
 agc043-D                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
-agc043-E                                 No result
+agc043-E                                 OK                   [(Singular: N),(Singular: A)] [('N', <class 'int'>), ('A', <class 'int'>)]
 agc043-F                                 No result
 agc044-A                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: A),(Singular: B),(Singular: C),(Singular: D)]] [('T', <class 'int'>)]
-agc044-B                                 No result
+agc044-B                                 OK                   [(Singular: N),(Parallel: P | 1 to N^2)] [('N', <class 'int'>), ('P', <class 'int'>)]
 agc044-C                                 OK                   [(Singular: N),(Singular: T)] [('N', <class 'int'>), ('T', <class 'str'>)]
 agc044-D                                 No result
 agc044-E                                 OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
@@ -3278,7 +3278,7 @@ agc056-E                                 OK                   [(Singular: N),(Pa
 agc056-F                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 agc057-A                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: L),(Singular: R)]] [('T', <class 'int'>)]
 agc057-B                                 OK                   [(Singular: N),(Singular: X),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>)]
-agc057-C                                 No result
+agc057-C                                 OK                   [(Singular: N),(Parallel: A | 0 to 2^N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
 agc057-D                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: S),(Singular: K)]] [('T', <class 'int'>)]
 agc057-E                                 OK                   [(Singular: H),(Singular: W),(TwoDimensional: B)] [('H', <class 'int'>), ('W', <class 'int'>), ('B', <class 'int'>)]
 agc057-F                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: a),(Singular: b),(Singular: c)]] [('T', <class 'int'>)]
@@ -3289,7 +3289,7 @@ agc058-D                                 OK                   [(Singular: A),(Si
 agc058-E                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: A | 1 to N)]] [('T', <class 'int'>)]
 agc058-F                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 agc059-A                                 OK                   [(Singular: N),(Singular: Q),(Singular: S),(Parallel: L,R | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('S', <class 'str'>), ('L', <class 'int'>), ('R', <class 'int'>)]
-agc059-B                                 Multiple results
+agc059-B                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: C | 1 to N)]] [('T', <class 'int'>)]
 agc059-C                                 No result
 agc059-D                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: K),(Parallel: B | 1 to N)]] [('T', <class 'int'>)]
 agc059-E                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: S)]] [('T', <class 'int'>)]
@@ -3319,7 +3319,7 @@ agc063-D                                 OK                   [(Singular: N),(Si
 agc063-E                                 OK                   [(Singular: N),(Parallel: P | 2 to N),(Singular: r),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>), ('r', <class 'int'>), ('A', <class 'int'>)]
 agc063-F                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Parallel: a | 1 to 2),(Parallel: b | 1 to 2)]] [('T', <class 'int'>)]
 agc064-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
-agc064-B                                 No result
+agc064-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b,c | 1 to M),(Singular: s)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'str'>), ('s', <class 'str'>)]
 agc064-C                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: l,r | 1 to N)]] [('T', <class 'int'>)]
 agc064-D                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 agc064-E                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: a | 1 to N),(Parallel: b | 1 to N)]] [('T', <class 'int'>)]
@@ -3346,7 +3346,7 @@ agc068-B                                 OK                   [(Singular: N),(Pa
 agc068-C                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: A | 1 to N)]] [('T', <class 'int'>)]
 agc068-D                                 OK                   [(Singular: N),(Singular: B),(Parallel: P | 2 to N)] [('N', <class 'int'>), ('B', <class 'int'>), ('P', <class 'int'>)]
 agc068-E                                 OK                   [(Singular: N),(Singular: M),(TwoDimensional: A)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
-agc069-A                                 No result
+agc069-A                                 OK                   [(Singular: N),(Parallel: l,r | 1 to 2^N)] [('N', <class 'int'>), ('l', <class 'int'>), ('r', <class 'int'>)]
 agc069-B                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: S | 1 to N)]] [('T', <class 'int'>)]
 agc069-C                                 OK                   [(Singular: N),(Singular: S),(Singular: T)] [('N', <class 'int'>), ('S', <class 'str'>), ('T', <class 'str'>)]
 agc069-D                                 OK                   [(Singular: N),(Singular: P)] [('N', <class 'int'>), ('P', <class 'int'>)]
@@ -3452,17 +3452,17 @@ apc001-G                                 OK                   [(Singular: N),(Si
 apc001-H                                 OK                   [(Singular: N),(Parallel: p | 1 to N-1),(Parallel: a | 0 to N-1)] [('N', <class 'int'>), ('p', <class 'int'>), ('a', <class 'int'>)]
 apc001-I                                 OK                   [(Singular: H),(Singular: W),(Singular: N),(Parallel: x,y | 1 to N)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 apc001-J                                 OK                   [(Singular: a),(Singular: b),(Singular: c),(Singular: A),(Singular: B),(Singular: C)] [('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-arc001-A                                 No result
+arc001-A                                 OK                   [(Singular: N),(Singular: c)] [('N', <class 'int'>), ('c', <class 'str'>)]
 arc001-B                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
 arc001-C                                 OK                   [(Parallel: c | 1 to 8)] [('c', <class 'str'>)]
 arc001-D                                 OK                   [(Singular: N),(Singular: start),(Singular: goal),(Parallel: l,r | 0 to N)] [('N', <class 'int'>), ('start', <class 'int'>), ('goal', <class 'int'>), ('l', <class 'int'>), ('r', <class 'int'>)]
 arc002-A                                 OK                   [(Singular: Y)] [('Y', <class 'int'>)]
 arc002-B                                 No result
-arc002-C                                 No result
-arc002-D                                 No result
-arc003-A                                 No result
+arc002-C                                 OK                   [(Singular: N),(Singular: c)] [('N', <class 'int'>), ('c', <class 'str'>)]
+arc002-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
+arc003-A                                 OK                   [(Singular: N),(Singular: r)] [('N', <class 'int'>), ('r', <class 'str'>)]
 arc003-B                                 OK                   [(Singular: N),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('s', <class 'str'>)]
-arc003-C                                 No result
+arc003-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: c | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('c', <class 'str'>)]
 arc003-D                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 arc004-A                                 OK                   [(Singular: N),(Parallel: x,y | 0 to N-1)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 arc004-B                                 OK                   [(Singular: N),(Parallel: d | 0 to N-1)] [('N', <class 'int'>), ('d', <class 'int'>)]
@@ -3470,16 +3470,16 @@ arc004-C                                 No result
 arc004-D                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 arc005-A                                 OK                   [(Singular: N),(Parallel: w | 0 to N-1)] [('N', <class 'int'>), ('w', <class 'str'>)]
 arc005-B                                 OK                   [(Singular: x),(Singular: y),(Singular: W),(Parallel: c | 1 to 9)] [('x', <class 'int'>), ('y', <class 'int'>), ('W', <class 'str'>), ('c', <class 'str'>)]
-arc005-C                                 No result
-arc005-D                                 No result
+arc005-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 0 to H-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
+arc005-D                                 OK                   [(Singular: b),(Singular: price)] [('b', <class 'str'>), ('price', <class 'int'>)]
 arc006-A                                 OK                   [(Parallel: E | 0 to 5),(Singular: B),(Parallel: L | 0 to 5)] [('E', <class 'int'>), ('B', <class 'int'>), ('L', <class 'int'>)]
 arc006-B                                 No result
 arc006-C                                 OK                   [(Singular: N),(Parallel: w | 1 to N)] [('N', <class 'int'>), ('w', <class 'int'>)]
-arc006-D                                 No result
+arc006-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 0 to H-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 arc007-A                                 OK                   [(Singular: X),(Singular: s)] [('X', <class 'str'>), ('s', <class 'str'>)]
 arc007-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: disk | 0 to M-1)] [('N', <class 'int'>), ('M', <class 'int'>), ('disk', <class 'int'>)]
-arc007-C                                 OK                   [(Parallel: c | 0 to 0)] [('c', <class 'str'>)]
-arc007-D                                 No result
+arc007-C                                 OK                   [(Singular: c)] [('c', <class 'str'>)]
+arc007-D                                 OK                   [(Singular: c)] [('c', <class 'str'>)]
 arc008-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 arc008-B                                 OK                   [(Singular: N),(Singular: M),(Singular: name),(Singular: kit)] [('N', <class 'int'>), ('M', <class 'int'>), ('name', <class 'str'>), ('kit', <class 'str'>)]
 arc008-C                                 OK                   [(Singular: N),(Parallel: x,y,t,r | 0 to N-1)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('t', <class 'int'>), ('r', <class 'int'>)]
@@ -3490,7 +3490,7 @@ arc009-C                                 OK                   [(Singular: N),(Si
 arc009-D                                 No result
 arc010-A                                 OK                   [(Singular: N),(Singular: M),(Singular: A),(Singular: B),(Parallel: c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('c', <class 'int'>)]
 arc010-B                                 No result
-arc010-C                                 No result
+arc010-C                                 OK                   [(Singular: n),(Singular: m),(Singular: Y),(Singular: Z),(Parallel: c,p | 1 to m),(Singular: b)] [('n', <class 'int'>), ('m', <class 'int'>), ('Y', <class 'int'>), ('Z', <class 'int'>), ('c', <class 'str'>), ('p', <class 'int'>), ('b', <class 'str'>)]
 arc010-D                                 OK                   [(Singular: N),(Parallel: f_x,f_y | 1 to N),(Singular: M),(Parallel: s_x,s_y | 1 to M)] [('N', <class 'int'>), ('f_x', <class 'int'>), ('f_y', <class 'int'>), ('M', <class 'int'>), ('s_x', <class 'int'>), ('s_y', <class 'int'>)]
 arc011-A                                 OK                   [(Singular: m),(Singular: n),(Singular: N)] [('m', <class 'int'>), ('n', <class 'int'>), ('N', <class 'int'>)]
 arc011-B                                 OK                   [(Singular: N),(Parallel: w | 0 to N-1)] [('N', <class 'int'>), ('w', <class 'str'>)]
@@ -3513,7 +3513,7 @@ arc015-B                                 OK                   [(Singular: N),(Pa
 arc015-C                                 OK                   [(Singular: N),(Parallel: large,m,small | 1 to N)] [('N', <class 'int'>), ('large', <class 'str'>), ('m', <class 'int'>), ('small', <class 'str'>)]
 arc015-D                                 OK                   [(Singular: T),(Singular: N),(Singular: P),(Parallel: q,x,t | 1 to N)] [('T', <class 'int'>), ('N', <class 'int'>), ('P', <class 'float'>), ('q', <class 'float'>), ('x', <class 'int'>), ('t', <class 'int'>)]
 arc016-A                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
-arc016-B                                 No result
+arc016-B                                 OK                   [(Singular: N),(Parallel: x | 1 to N)] [('N', <class 'int'>), ('x', <class 'str'>)]
 arc016-C                                 No result
 arc016-D                                 OK                   [(Singular: N),(Singular: M),(Singular: H),(Parallel: f,t | 1 to M),(Parallel: D | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('H', <class 'int'>), ('f', <class 'int'>), ('t', <class 'int'>), ('D', <class 'int'>)]
 arc017-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -3526,7 +3526,7 @@ arc018-C                                 No result
 arc018-D                                 OK                   [(Singular: N),(Singular: M),(Parallel: A,B,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 arc019-A                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 arc019-B                                 OK                   [(Singular: A)] [('A', <class 'str'>)]
-arc019-C                                 No result
+arc019-C                                 OK                   [(Singular: R),(Singular: C),(Singular: K),(Parallel: s | 1 to R)] [('R', <class 'int'>), ('C', <class 'int'>), ('K', <class 'int'>), ('s', <class 'str'>)]
 arc020-A                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
 arc020-B                                 OK                   [(Singular: n),(Singular: c),(Parallel: a | 1 to n)] [('n', <class 'int'>), ('c', <class 'int'>), ('a', <class 'int'>)]
 arc020-C                                 OK                   [(Singular: N),(Parallel: a,L | 1 to N),(Singular: B)] [('N', <class 'int'>), ('a', <class 'int'>), ('L', <class 'int'>), ('B', <class 'int'>)]
@@ -3571,7 +3571,7 @@ arc030-B                                 OK                   [(Singular: n),(Si
 arc030-C                                 OK                   [(Singular: n),(Singular: m),(Singular: k),(Parallel: c | 1 to n),(Parallel: a,b | 1 to m)] [('n', <class 'int'>), ('m', <class 'int'>), ('k', <class 'int'>), ('c', <class 'str'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 arc030-D                                 No result
 arc031-A                                 OK                   [(Singular: Name)] [('Name', <class 'str'>)]
-arc031-B                                 No result
+arc031-B                                 OK                   [(Parallel: A | 1 to 10)] [('A', <class 'str'>)]
 arc031-C                                 OK                   [(Singular: N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('B', <class 'int'>)]
 arc031-D                                 No result
 arc032-A                                 OK                   [(Singular: n)] [('n', <class 'int'>)]
@@ -3599,19 +3599,19 @@ arc037-B                                 OK                   [(Singular: N),(Si
 arc037-C                                 OK                   [(Singular: N),(Singular: K),(Parallel: a | 1 to N),(Parallel: b | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 arc037-D                                 OK                   [(Singular: L)] [('L', <class 'int'>)]
 arc038-A                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-arc038-B                                 No result
+arc038-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 arc038-C                                 OK                   [(Singular: N),(Parallel: C,A | 1 to N-1)] [('N', <class 'int'>), ('C', <class 'int'>), ('A', <class 'int'>)]
 arc038-D                                 OK                   [(Singular: N),(Singular: M),(Parallel: X | 1 to N),(Parallel: A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 arc039-A                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
 arc039-B                                 OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
-arc039-C                                 No result
+arc039-C                                 OK                   [(Singular: K),(Singular: S)] [('K', <class 'int'>), ('S', <class 'str'>)]
 arc039-D                                 OK                   [(Singular: N),(Singular: M),(Parallel: X,Y | 1 to M),(Singular: Q),(Parallel: A,B,C | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 arc040-A                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 arc040-B                                 OK                   [(Singular: N),(Singular: R),(Singular: S)] [('N', <class 'int'>), ('R', <class 'int'>), ('S', <class 'str'>)]
 arc040-C                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 arc040-D                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 arc041-A                                 OK                   [(Singular: x),(Singular: y),(Singular: k)] [('x', <class 'int'>), ('y', <class 'int'>), ('k', <class 'int'>)]
-arc041-B                                 No result
+arc041-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: b | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('b', <class 'str'>)]
 arc041-C                                 OK                   [(Singular: N),(Singular: L),(Parallel: x,d | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>), ('x', <class 'int'>), ('d', <class 'str'>)]
 arc041-D                                 OK                   [(Singular: N),(Singular: M),(Parallel: a,b,c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'str'>)]
 arc042-A                                 OK                   [(Singular: N),(Singular: M),(Parallel: a | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>)]
@@ -3669,14 +3669,14 @@ arc054-D                                 OK                   [(Singular: N),(Pa
 arc055-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 arc055-B                                 OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
 arc055-C                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
-arc055-D                                 No result
+arc055-D                                 OK                   [(Singular: d)] [('d', <class 'int'>)]
 arc056-A                                 OK                   [(Singular: A),(Singular: B),(Singular: K),(Singular: L)] [('A', <class 'int'>), ('B', <class 'int'>), ('K', <class 'int'>), ('L', <class 'int'>)]
 arc056-B                                 OK                   [(Singular: N),(Singular: M),(Singular: S),(Parallel: u,v | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
 arc056-C                                 OK                   [(Singular: N),(Singular: K),(TwoDimensional: w)] [('N', <class 'int'>), ('K', <class 'int'>), ('w', <class 'int'>)]
 arc056-D                                 No result
 arc057-A                                 OK                   [(Singular: A),(Singular: K)] [('A', <class 'int'>), ('K', <class 'int'>)]
 arc057-B                                 OK                   [(Singular: N),(Singular: K),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>)]
-arc057-C                                 No result
+arc057-C                                 OK                   [(Singular: a)] [('a', <class 'str'>)]
 arc057-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc058-C                                 OK                   [(Singular: N),(Singular: K),(Parallel: D | 1 to K)] [('N', <class 'int'>), ('K', <class 'int'>), ('D', <class 'int'>)]
 arc058-D                                 OK                   [(Singular: H),(Singular: W),(Singular: A),(Singular: B)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
@@ -3745,7 +3745,7 @@ arc073-F                                 OK                   [(Singular: N),(Si
 arc074-C                                 OK                   [(Singular: H),(Singular: W)] [('H', <class 'int'>), ('W', <class 'int'>)]
 arc074-D                                 OK                   [(Singular: N),(Parallel: a | 1 to 3*N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 arc074-E                                 OK                   [(Singular: N),(Singular: M),(Parallel: l,r,x | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('l', <class 'int'>), ('r', <class 'int'>), ('x', <class 'int'>)]
-arc074-F                                 No result
+arc074-F                                 OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 arc075-C                                 OK                   [(Singular: N),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('s', <class 'int'>)]
 arc075-D                                 OK                   [(Singular: N),(Singular: A),(Singular: B),(Parallel: h | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('h', <class 'int'>)]
 arc075-E                                 OK                   [(Singular: N),(Singular: K),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>)]
@@ -3837,7 +3837,7 @@ arc096-F                                 No result
 arc097-C                                 OK                   [(Singular: s),(Singular: K)] [('s', <class 'str'>), ('K', <class 'int'>)]
 arc097-D                                 OK                   [(Singular: N),(Singular: M),(Parallel: p | 1 to N),(Parallel: x,y | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('p', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 arc097-E                                 OK                   [(Singular: N),(Parallel: c,a | 1 to 2*N)] [('N', <class 'int'>), ('c', <class 'str'>), ('a', <class 'int'>)]
-arc097-F                                 No result
+arc097-F                                 OK                   [(Singular: N),(Parallel: x,y | 1 to N-1),(Singular: c)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('c', <class 'str'>)]
 arc098-C                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 arc098-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc098-E                                 OK                   [(Singular: N),(Singular: K),(Singular: Q),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>)]
@@ -3848,7 +3848,7 @@ arc099-E                                 OK                   [(Singular: N),(Si
 arc099-F                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 arc100-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc100-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-arc100-E                                 No result
+arc100-E                                 OK                   [(Singular: N),(Parallel: A | 0 to 2^N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc100-F                                 OK                   [(Singular: N),(Singular: K),(Singular: M),(Parallel: A | 1 to M)] [('N', <class 'int'>), ('K', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
 arc101-C                                 OK                   [(Singular: N),(Singular: K),(Parallel: x | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('x', <class 'int'>)]
 arc101-D                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
@@ -3889,7 +3889,7 @@ arc107-F                                 OK                   [(Singular: N),(Si
 arc108-A                                 OK                   [(Singular: S),(Singular: P)] [('S', <class 'int'>), ('P', <class 'int'>)]
 arc108-B                                 OK                   [(Singular: N),(Singular: s)] [('N', <class 'int'>), ('s', <class 'str'>)]
 arc108-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: u,v,c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>), ('c', <class 'int'>)]
-arc108-D                                 No result
+arc108-D                                 OK                   [(Singular: N),(Singular: c_mathrmAA),(Singular: c_mathrmAB),(Singular: c_mathrmBA),(Singular: c_mathrmBB)] [('N', <class 'int'>), ('c_mathrmAA', <class 'str'>), ('c_mathrmAB', <class 'str'>), ('c_mathrmBA', <class 'str'>), ('c_mathrmBB', <class 'str'>)]
 arc108-E                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 arc108-F                                 OK                   [(Singular: N),(Parallel: a,b | 1 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 arc109-A                                 OK                   [(Singular: a),(Singular: b),(Singular: x),(Singular: y)] [('a', <class 'int'>), ('b', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
@@ -3913,7 +3913,7 @@ arc111-F                                 OK                   [(Singular: N),(Si
 arc112-A                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: L),(Singular: R)]] [('T', <class 'int'>)]
 arc112-B                                 OK                   [(Singular: B),(Singular: C)] [('B', <class 'int'>), ('C', <class 'int'>)]
 arc112-C                                 OK                   [(Singular: n),(Parallel: p | 2 to n)] [('n', <class 'int'>), ('p', <class 'int'>)]
-arc112-D                                 No result
+arc112-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 arc112-E                                 OK                   [(Singular: n),(Singular: m),(Parallel: a | 1 to n)] [('n', <class 'int'>), ('m', <class 'int'>), ('a', <class 'int'>)]
 arc112-F                                 OK                   [(Singular: n),(Singular: m),(Parallel: c | 1 to n),(TwoDimensional: s)] [('n', <class 'int'>), ('m', <class 'int'>), ('c', <class 'int'>), ('s', <class 'int'>)]
 arc113-A                                 OK                   [(Singular: K)] [('K', <class 'int'>)]
@@ -3955,7 +3955,7 @@ arc118-F                                 OK                   [(Singular: N),(Si
 arc119-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 arc119-B                                 OK                   [(Singular: N),(Singular: S),(Singular: T)] [('N', <class 'int'>), ('S', <class 'str'>), ('T', <class 'str'>)]
 arc119-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-arc119-D                                 No result
+arc119-D                                 OK                   [(Singular: H),(Singular: W),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('s', <class 'str'>)]
 arc119-E                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc119-F                                 OK                   [(Singular: N),(Singular: K),(Parallel: c | 1 to 1)] [('N', <class 'int'>), ('K', <class 'int'>), ('c', <class 'str'>)]
 arc120-A                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
@@ -4026,7 +4026,7 @@ arc130-D                                 OK                   [(Singular: N),(Pa
 arc130-E                                 OK                   [(Singular: N),(Singular: K),(Parallel: i | 1 to K)] [('N', <class 'int'>), ('K', <class 'int'>), ('i', <class 'int'>)]
 arc130-F                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc131-A                                 OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
-arc131-B                                 No result
+arc131-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 arc131-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc131-D                                 OK                   [(Singular: N),(Singular: M),(Singular: D),(Parallel: r | 0 to M),(Parallel: s | 0 to M-1)] [('N', <class 'int'>), ('M', <class 'int'>), ('D', <class 'int'>), ('r', <class 'int'>), ('s', <class 'int'>)]
 arc131-E                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -4114,7 +4114,7 @@ arc145-B                                 OK                   [(Singular: N),(Si
 arc145-C                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
 arc145-D                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 arc145-E                                 OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-arc145-F                                 No result
+arc145-F                                 OK                   [(Singular: N),(Singular: M),(Singular: mathrmMOD)] [('N', <class 'int'>), ('M', <class 'int'>), ('mathrmMOD', <class 'int'>)]
 arc146-A                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc146-B                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 arc146-C                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -4148,17 +4148,17 @@ arc150-F                                 OK                   [(Singular: N),(Si
 arc151-A                                 OK                   [(Singular: N),(Singular: S),(Singular: T)] [('N', <class 'int'>), ('S', <class 'str'>), ('T', <class 'int'>)]
 arc151-B                                 OK                   [(Singular: N),(Singular: M),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('P', <class 'int'>)]
 arc151-C                                 OK                   [(Singular: N),(Singular: M),(Parallel: X,Y | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
-arc151-D                                 No result
+arc151-D                                 OK                   [(Singular: N),(Singular: Q),(Parallel: A | 0 to 2^N-1),(Parallel: X,Y | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 arc151-E                                 OK                   [(Singular: N),(Parallel: A | 1 to N),(Singular: P),(Parallel: X | 1 to P),(Singular: Q),(Parallel: Y | 1 to Q)] [('N', <class 'int'>), ('A', <class 'int'>), ('P', <class 'int'>), ('X', <class 'int'>), ('Q', <class 'int'>), ('Y', <class 'int'>)]
 arc151-F                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Parallel: R,G,B | 1 to 2)]] [('T', <class 'int'>)]
 arc152-A                                 OK                   [(Singular: N),(Singular: L),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>), ('a', <class 'int'>)]
 arc152-B                                 OK                   [(Singular: N),(Singular: L),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>), ('a', <class 'int'>)]
 arc152-C                                 OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 arc152-D                                 OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
-arc152-E                                 No result
+arc152-E                                 OK                   [(Singular: N),(Parallel: w | 1 to 2^N-1)] [('N', <class 'int'>), ('w', <class 'int'>)]
 arc152-F                                 OK                   [(Singular: N),(Parallel: a,b | 1 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 arc153-A                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
-arc153-B                                 No result
+arc153-B                                 OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H),(Singular: Q),(Parallel: a,b | 1 to Q)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>), ('Q', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 arc153-C                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc153-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc153-E                                 OK                   [(Singular: Y)] [('Y', <class 'int'>)]
@@ -4273,10 +4273,10 @@ arc171-E                                 OK                   [(Singular: N),(Si
 arc171-F                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 arc172-A                                 OK                   [(Singular: H),(Singular: W),(Singular: N),(Parallel: A | 1 to N)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('A', <class 'int'>)]
 arc172-B                                 OK                   [(Singular: N),(Singular: K),(Singular: L)] [('N', <class 'int'>), ('K', <class 'int'>), ('L', <class 'int'>)]
-arc172-C                                 No result
+arc172-C                                 OK                   [(Singular: N),(Singular: c)] [('N', <class 'int'>), ('c', <class 'str'>)]
 arc172-D                                 No result
 arc172-E                                 OK                   [RepeatedCase: prefix=[(Singular: Q)], count=Q, case=[(Singular: X)]] [('Q', <class 'int'>)]
-arc172-F                                 No result
+arc172-F                                 OK                   [(Singular: N),(Singular: s),(Singular: t)] [('N', <class 'int'>), ('s', <class 'str'>), ('t', <class 'str'>)]
 arc173-A                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: K)]] [('T', <class 'int'>)]
 arc173-B                                 OK                   [(Singular: N),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 arc173-C                                 OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
@@ -4302,8 +4302,8 @@ arc176-D                                 OK                   [(Singular: N),(Si
 arc176-E                                 OK                   [(Singular: N),(Singular: M),(Parallel: X | 1 to N),(Parallel: Y | 1 to N),(TwoDimensional: A)] [('N', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('A', <class 'int'>)]
 arc176-F                                 OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 arc177-A                                 OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: D),(Singular: E),(Singular: F),(Singular: N),(Parallel: X | 1 to N)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>), ('E', <class 'int'>), ('F', <class 'int'>), ('N', <class 'int'>), ('X', <class 'int'>)]
-arc177-B                                 No result
-arc177-C                                 No result
+arc177-B                                 OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
+arc177-C                                 OK                   [(Singular: N),(Parallel: c | 1 to N)] [('N', <class 'int'>), ('c', <class 'str'>)]
 arc177-D                                 OK                   [(Singular: N),(Singular: H),(Parallel: X | 1 to N)] [('N', <class 'int'>), ('H', <class 'int'>), ('X', <class 'int'>)]
 arc177-E                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(TwoDimensional: A),(Parallel: R | 1 to N)]] [('T', <class 'int'>)]
 arc177-F                                 OK                   [(Singular: L),(Singular: N),(Parallel: S | 1 to 1),(Parallel: X,C | 1 to N)] [('L', <class 'int'>), ('N', <class 'int'>), ('S', <class 'str'>), ('X', <class 'int'>), ('C', <class 'str'>)]
@@ -4388,7 +4388,7 @@ arc192-C                                 No result
 arc192-D                                 OK                   [(Singular: N),(Parallel: A | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
 arc192-E                                 OK                   [(Singular: W),(Singular: H),(Singular: L),(Singular: R),(Singular: D),(Singular: U)] [('W', <class 'int'>), ('H', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>), ('D', <class 'int'>), ('U', <class 'int'>)]
 arc193-A                                 OK                   [(Singular: N),(Parallel: W | 1 to N),(Parallel: L,R | 1 to N),(Singular: Q),(Parallel: s,t | 1 to Q)] [('N', <class 'int'>), ('W', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>), ('Q', <class 'int'>), ('s', <class 'int'>), ('t', <class 'int'>)]
-arc193-B                                 No result
+arc193-B                                 OK                   [(Singular: N),(Singular: s)] [('N', <class 'int'>), ('s', <class 'str'>)]
 arc193-C                                 OK                   [(Singular: H),(Singular: W),(Singular: C)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'int'>)]
 arc193-D                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: A),(Singular: B)]] [('T', <class 'int'>)]
 arc194-A                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
@@ -4489,7 +4489,7 @@ arc213-A                                 No result
 arc213-B                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: q),(Singular: L),(Singular: R)]] [('T', <class 'int'>)]
 arc213-C                                 OK                   [RepeatedCase: prefix=[(Singular: t)], count=t, case=[(Singular: N),(Parallel: A | 1 to N),(Parallel: u,v | 1 to N-1),(Parallel: b,c | 1 to N-1)]] [('t', <class 'int'>)]
 arc213-D                                 OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
-arc214-A                                 No result
+arc214-A                                 OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 arc214-B                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: M),(Parallel: A,B,X | 1 to M)]] [('T', <class 'int'>)]
 arc214-C                                 OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
 arc214-D                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -4553,10 +4553,10 @@ arc224-D                                 OK                   [RepeatedCase: pre
 arc224-E                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: S)]] [('T', <class 'int'>)]
 arc224-F                                 OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: K),(Parallel: A | 1 to N)]] [('T', <class 'int'>)]
 asprocon7-A                              No result
-atc001-A                                 No result
+atc001-A                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 0 to H-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 atc001-B                                 OK                   [(Singular: N),(Singular: Q),(Parallel: P,A,B | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('P', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 atc001-C                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-atc002-A                                 No result
+atc002-A                                 OK                   [(Singular: R),(Singular: C),(Singular: sy),(Singular: sx),(Singular: gy),(Singular: gx),(Parallel: c | 1 to R)] [('R', <class 'int'>), ('C', <class 'int'>), ('sy', <class 'int'>), ('sx', <class 'int'>), ('gy', <class 'int'>), ('gx', <class 'int'>), ('c', <class 'str'>)]
 atc002-B                                 OK                   [(Singular: N),(Singular: M),(Singular: P)] [('N', <class 'int'>), ('M', <class 'int'>), ('P', <class 'int'>)]
 atc002-C                                 No result
 atcoder13live-A                          No result
@@ -4564,20 +4564,20 @@ autumn_fest-A                            No result
 autumn_fest-B                            No result
 autumn_fest-C                            No result
 autumn_fest-D                            OK                   [(Singular: n),(Singular: M)] [('n', <class 'int'>), ('M', <class 'int'>)]
-autumn_fest-E                            No result
-autumn_fest-H                            No result
+autumn_fest-E                            OK                   [(Singular: N),(Parallel: x,y | 0 to N-1)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
+autumn_fest-H                            OK                   [(Singular: N),(Singular: D),(Parallel: left,right | 1 to N)] [('N', <class 'int'>), ('D', <class 'int'>), ('left', <class 'int'>), ('right', <class 'int'>)]
 autumn_fest-J                            OK                   [(Singular: H),(Singular: T)] [('H', <class 'int'>), ('T', <class 'int'>)]
 autumn_fest-K                            No result
 awtf2024-A                               OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 awtf2024-B                               OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 awtf2024-C                               OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: L),(Singular: C),(Parallel: X | 1 to N),(Parallel: K | 1 to N)]] [('T', <class 'int'>)]
 awtf2024-D                               OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
-awtf2024-E                               Multiple results
+awtf2024-E                               OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: K),(Parallel: H,W,A,B | 1 to K)]] [('T', <class 'int'>)]
 awtf2024-open-A                          OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 awtf2024-open-B                          OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 awtf2024-open-C                          OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: L),(Singular: C),(Parallel: X | 1 to N),(Parallel: K | 1 to N)]] [('T', <class 'int'>)]
 awtf2024-open-D                          OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
-awtf2024-open-E                          Multiple results
+awtf2024-open-E                          OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: K),(Parallel: H,W,A,B | 1 to K)]] [('T', <class 'int'>)]
 awtf2025algo-A                           OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: P | 1 to N)]] [('T', <class 'int'>)]
 awtf2025algo-B                           OK                   [(Singular: N),(Singular: M),(Parallel: L,R | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 awtf2025algo-C                           OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: A | 1 to N)]] [('T', <class 'int'>)]
@@ -4591,12 +4591,12 @@ awtf2025algo-open-E                      OK                   [(Singular: N),(Si
 awtf2026algo-A                           OK                   [RepeatedCase: prefix=[(Singular: S)], count=S, case=[(Singular: N),(Parallel: A,B,C | 1 to N-1)]] [('S', <class 'int'>)]
 awtf2026algo-B                           OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 awtf2026algo-C                           OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-awtf2026algo-D                           Multiple results
+awtf2026algo-D                           OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: P | 1 to N),(Parallel: Q | 1 to N)]] [('T', <class 'int'>)]
 awtf2026algo-E                           OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: M),(Parallel: S | 1 to N)]] [('T', <class 'int'>)]
 awtf2026algo-open-A                      OK                   [RepeatedCase: prefix=[(Singular: S)], count=S, case=[(Singular: N),(Parallel: A,B,C | 1 to N-1)]] [('S', <class 'int'>)]
 awtf2026algo-open-B                      OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 awtf2026algo-open-C                      OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-awtf2026algo-open-D                      Multiple results
+awtf2026algo-open-D                      OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: P | 1 to N),(Parallel: Q | 1 to N)]] [('T', <class 'int'>)]
 awtf2026algo-open-E                      OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: M),(Parallel: S | 1 to N)]] [('T', <class 'int'>)]
 awtf2026heuristic-A                      No result
 bcu30-2018-A                             OK                   [(Singular: N),(Parallel: A | 1 to N),(Singular: M),(Parallel: B | 1 to M)] [('N', <class 'int'>), ('A', <class 'int'>), ('M', <class 'int'>), ('B', <class 'int'>)]
@@ -4609,7 +4609,7 @@ bcu30-A                                  OK                   [(Singular: N),(Si
 bcu30-B                                  OK                   [(Parallel: s | 1 to 9)] [('s', <class 'int'>)]
 bcu30-C                                  OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 bcu30-D                                  OK                   [(Singular: N),(Singular: Q),(Parallel: x | 1 to N),(Parallel: t | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('x', <class 'int'>), ('t', <class 'int'>)]
-bcu30-E                                  No result
+bcu30-E                                  OK                   [(Singular: N),(Singular: K),(Singular: Q),(Parallel: s | 1 to N),(TwoDimensional: r),(TwoDimensional: c)] [('N', <class 'int'>), ('K', <class 'int'>), ('Q', <class 'int'>), ('s', <class 'str'>), ('r', <class 'int'>), ('c', <class 'int'>)]
 bcu30-F                                  OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 birthday0410-E                           No result
 birthday0410-F                           No result
@@ -4619,7 +4619,7 @@ bitflyer2018-final-B                     OK                   [(Singular: N),(Si
 bitflyer2018-final-C                     OK                   [(Singular: S)] [('S', <class 'str'>)]
 bitflyer2018-final-D                     OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 bitflyer2018-final-E                     No result
-bitflyer2018-final-F                     No result
+bitflyer2018-final-F                     OK                   [(Singular: H),(Singular: W),(Singular: Q),(Parallel: s | 1 to H),(Parallel: r,c | 1 to Q-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('Q', <class 'int'>), ('s', <class 'str'>), ('r', <class 'int'>), ('c', <class 'int'>)]
 bitflyer2018-final-G                     OK                   [(Singular: N),(Singular: M),(Parallel: A,B,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 bitflyer2018-final-H                     OK                   [(Parallel: X,Y | 1 to 3),(Singular: W),(Singular: H)] [('X', <class 'int'>), ('Y', <class 'int'>), ('W', <class 'int'>), ('H', <class 'int'>)]
 bitflyer2018-final-open-A                OK                   [(Singular: N),(Parallel: p | 1 to N)] [('N', <class 'int'>), ('p', <class 'int'>)]
@@ -4627,7 +4627,7 @@ bitflyer2018-final-open-B                OK                   [(Singular: N),(Si
 bitflyer2018-final-open-C                OK                   [(Singular: S)] [('S', <class 'str'>)]
 bitflyer2018-final-open-D                OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 bitflyer2018-final-open-E                No result
-bitflyer2018-final-open-F                No result
+bitflyer2018-final-open-F                OK                   [(Singular: H),(Singular: W),(Singular: Q),(Parallel: s | 1 to H),(Parallel: r,c | 1 to Q-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('Q', <class 'int'>), ('s', <class 'str'>), ('r', <class 'int'>), ('c', <class 'int'>)]
 bitflyer2018-final-open-G                OK                   [(Singular: N),(Singular: M),(Parallel: A,B,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 bitflyer2018-final-open-H                OK                   [(Parallel: X,Y | 1 to 3),(Singular: W),(Singular: H)] [('X', <class 'int'>), ('Y', <class 'int'>), ('W', <class 'int'>), ('H', <class 'int'>)]
 bitflyer2018-qual-A                      OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
@@ -4675,7 +4675,7 @@ cf16-final-E                             OK                   [(Singular: N),(Si
 cf16-final-F                             OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 cf16-final-G                             OK                   [(Singular: N),(Singular: Q),(Parallel: A,B,C | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 cf16-final-H                             OK                   [(Singular: N),(Parallel: A | 1 to N-1),(Singular: M),(Parallel: X | 1 to M)] [('N', <class 'int'>), ('A', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>)]
-cf16-final-I                             No result
+cf16-final-I                             OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 cf16-final-J                             OK                   [(Singular: N),(Parallel: U | 1 to N),(Parallel: D | 1 to N),(Parallel: L | 1 to N),(Parallel: R | 1 to N)] [('N', <class 'int'>), ('U', <class 'int'>), ('D', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 cf16-final-open-A                        OK                   [(Singular: H),(Singular: W),(TwoDimensional: S)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 cf16-final-open-B                        OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -4685,11 +4685,11 @@ cf16-final-open-E                        OK                   [(Singular: N),(Si
 cf16-final-open-F                        OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 cf16-final-open-G                        OK                   [(Singular: N),(Singular: Q),(Parallel: A,B,C | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 cf16-final-open-H                        OK                   [(Singular: N),(Parallel: A | 1 to N-1),(Singular: M),(Parallel: X | 1 to M)] [('N', <class 'int'>), ('A', <class 'int'>), ('M', <class 'int'>), ('X', <class 'int'>)]
-cf16-final-open-I                        No result
+cf16-final-open-I                        OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 cf16-final-open-J                        OK                   [(Singular: N),(Parallel: U | 1 to N),(Parallel: D | 1 to N),(Parallel: L | 1 to N),(Parallel: R | 1 to N)] [('N', <class 'int'>), ('U', <class 'int'>), ('D', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 cf16-relay-open-A                        OK                   [(Parallel: R | 1 to 2)] [('R', <class 'int'>)]
 cf16-relay-open-B                        OK                   [(Singular: S)] [('S', <class 'str'>)]
-cf16-relay-open-C                        No result
+cf16-relay-open-C                        OK                   [(Singular: N),(Parallel: A | 1 to 2^N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 cf16-relay-open-D                        OK                   [(Singular: A),(Singular: B),(Singular: C)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 cf16-relay-open-E                        OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: D)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 cf16-relay-open-F                        OK                   [(Singular: X)] [('X', <class 'int'>)]
@@ -4713,8 +4713,8 @@ cf17-final-D                             OK                   [(Singular: N),(Pa
 cf17-final-E                             OK                   [(Singular: S),(Singular: N),(Parallel: L,R | 1 to N)] [('S', <class 'str'>), ('N', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 cf17-final-F                             No result
 cf17-final-G                             OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
-cf17-final-H                             OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
-cf17-final-I                             No result
+cf17-final-H                             OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+cf17-final-I                             OK                   [(Singular: N),(Parallel: A | 1 to 2^N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 cf17-final-J                             OK                   [(Singular: N),(Parallel: X | 1 to N),(Parallel: A,B,C | 1 to N-1)] [('N', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 cf17-final-open-A                        OK                   [(Singular: S)] [('S', <class 'str'>)]
 cf17-final-open-B                        OK                   [(Singular: S)] [('S', <class 'str'>)]
@@ -4723,8 +4723,8 @@ cf17-final-open-D                        OK                   [(Singular: N),(Pa
 cf17-final-open-E                        OK                   [(Singular: S),(Singular: N),(Parallel: L,R | 1 to N)] [('S', <class 'str'>), ('N', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 cf17-final-open-F                        No result
 cf17-final-open-G                        OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
-cf17-final-open-H                        OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
-cf17-final-open-I                        No result
+cf17-final-open-H                        OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+cf17-final-open-I                        OK                   [(Singular: N),(Parallel: A | 1 to 2^N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 cf17-final-open-J                        OK                   [(Singular: N),(Parallel: X | 1 to N),(Parallel: A,B,C | 1 to N-1)] [('N', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 cf17-relay-open-A                        OK                   [(Singular: K),(Singular: A),(Singular: B)] [('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 cf17-relay-open-B                        OK                   [(Singular: N),(Singular: Q),(Parallel: v,w | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('v', <class 'int'>), ('w', <class 'int'>)]
@@ -4769,10 +4769,10 @@ chokudai_S002-L                          OK                   [(Singular: N),(Pa
 code-festival-2014-china-open-A          OK                   [(Singular: n)] [('n', <class 'int'>)]
 code-festival-2014-china-open-B          OK                   [(Singular: Q),(Parallel: n | 1 to Q)] [('Q', <class 'int'>), ('n', <class 'int'>)]
 code-festival-2014-china-open-C          OK                   [(Singular: N),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
-code-festival-2014-china-open-D          No result
+code-festival-2014-china-open-D          OK                   [(Singular: H),(Singular: W),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('s', <class 'str'>)]
 code-festival-2014-china-open-E          OK                   [(Parallel: N | 1 to 3),(Parallel: P | 1 to 3)] [('N', <class 'int'>), ('P', <class 'int'>)]
 code-festival-2014-china-open-F          OK                   [(Singular: N),(Parallel: s,t | 1 to N)] [('N', <class 'int'>), ('s', <class 'int'>), ('t', <class 'int'>)]
-code-festival-2014-china-open-G          No result
+code-festival-2014-china-open-G          OK                   [(Singular: R),(Singular: C),(Parallel: s | 1 to R),(Singular: a),(Singular: b)] [('R', <class 'int'>), ('C', <class 'int'>), ('s', <class 'str'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 code-festival-2014-china-open-H          OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 code-festival-2014-china-open-I          OK                   [(Singular: N),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('s', <class 'str'>)]
 code-festival-2014-exhibition-A          OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M),(Parallel: y | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('y', <class 'int'>)]
@@ -4874,13 +4874,13 @@ code-festival-2015-qualb-B               OK                   [(Singular: N),(Si
 code-festival-2015-qualb-C               OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 code-festival-2015-qualb-D               OK                   [(Singular: N),(Parallel: S,C | 1 to N)] [('N', <class 'int'>), ('S', <class 'int'>), ('C', <class 'int'>)]
 code-festival-2015-relay-A               OK                   [(Singular: T)] [('T', <class 'int'>)]
-code-festival-2015-relay-B               No result
+code-festival-2015-relay-B               OK                   [(Parallel: p | 1 to 10)] [('p', <class 'str'>)]
 code-festival-2015-relay-C               OK                   [(Singular: N)] [('N', <class 'int'>)]
 code-festival-2015-relay-D               OK                   [(Singular: N)] [('N', <class 'int'>)]
 code-festival-2015-relay-E               OK                   [(Singular: ht),(Singular: mt),(Singular: hn),(Singular: mn)] [('ht', <class 'int'>), ('mt', <class 'int'>), ('hn', <class 'int'>), ('mn', <class 'int'>)]
 code-festival-2015-relay-F               No result
 code-festival-2015-relay-G               OK                   [(Singular: N),(Singular: M),(Singular: L),(Parallel: A,B | 1 to N),(Parallel: C,D | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('L', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
-code-festival-2015-relay-H               No result
+code-festival-2015-relay-H               OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'int'>)]
 code-festival-2015-relay-I               OK                   [(Singular: N),(Parallel: k,d | 1 to N)] [('N', <class 'int'>), ('k', <class 'int'>), ('d', <class 'int'>)]
 code-festival-2015-relay-J               OK                   [(Singular: X),(Singular: Y)] [('X', <class 'int'>), ('Y', <class 'int'>)]
 code-festival-2016-quala-A               OK                   [(Singular: s)] [('s', <class 'str'>)]
@@ -4892,15 +4892,15 @@ code-festival-2016-qualb-A               OK                   [(Singular: S)] [(
 code-festival-2016-qualb-B               OK                   [(Singular: N),(Singular: A),(Singular: B),(Singular: S)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('S', <class 'str'>)]
 code-festival-2016-qualb-C               OK                   [(Singular: W),(Singular: H),(Parallel: p | 0 to W-1),(Parallel: q | 0 to H-1)] [('W', <class 'int'>), ('H', <class 'int'>), ('p', <class 'int'>), ('q', <class 'int'>)]
 code-festival-2016-qualb-D               OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-code-festival-2016-qualb-E               No result
+code-festival-2016-qualb-E               OK                   [(Singular: N),(Parallel: S | 1 to N),(Singular: Q),(Parallel: k,p | 1 to Q)] [('N', <class 'int'>), ('S', <class 'str'>), ('Q', <class 'int'>), ('k', <class 'int'>), ('p', <class 'str'>)]
 code-festival-2016-qualc-A               OK                   [(Singular: s)] [('s', <class 'str'>)]
 code-festival-2016-qualc-B               OK                   [(Singular: K),(Singular: T),(Parallel: a | 1 to T)] [('K', <class 'int'>), ('T', <class 'int'>), ('a', <class 'int'>)]
 code-festival-2016-qualc-C               OK                   [(Singular: N),(Parallel: T | 1 to N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
-code-festival-2016-qualc-D               No result
+code-festival-2016-qualc-D               OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 code-festival-2016-qualc-E               OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
 code-festival-2017-quala-A               OK                   [(Singular: S)] [('S', <class 'str'>)]
 code-festival-2017-quala-B               OK                   [(Singular: N),(Singular: M),(Singular: K)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>)]
-code-festival-2017-quala-C               No result
+code-festival-2017-quala-C               OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 code-festival-2017-quala-D               OK                   [(Singular: H),(Singular: W),(Singular: d)] [('H', <class 'int'>), ('W', <class 'int'>), ('d', <class 'int'>)]
 code-festival-2017-quala-E               OK                   [(Singular: N),(Singular: M),(Singular: A),(Singular: B),(Singular: C),(Singular: D)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'str'>), ('B', <class 'str'>), ('C', <class 'str'>), ('D', <class 'str'>)]
 code-festival-2017-quala-F               OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
@@ -5099,7 +5099,7 @@ ddcc2017-final-E                         OK                   [(Singular: N),(Pa
 ddcc2017-qual-A                          OK                   [(Singular: S)] [('S', <class 'str'>)]
 ddcc2017-qual-B                          OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: D)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 ddcc2017-qual-C                          OK                   [(Singular: N),(Singular: C),(Parallel: L | 1 to N)] [('N', <class 'int'>), ('C', <class 'int'>), ('L', <class 'int'>)]
-ddcc2017-qual-D                          No result
+ddcc2017-qual-D                          OK                   [(Singular: H),(Singular: W),(Singular: A),(Singular: B),(Parallel: m | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('m', <class 'str'>)]
 ddcc2019-final-A                         OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 ddcc2019-final-B                         OK                   [(Singular: N),(Singular: K),(Singular: R)] [('N', <class 'int'>), ('K', <class 'int'>), ('R', <class 'int'>)]
 ddcc2019-final-C                         No result
@@ -5116,11 +5116,11 @@ ddcc2020-final-C                         OK                   [(Singular: N),(Pa
 ddcc2020-final-D                         OK                   [(Singular: N),(Parallel: A,B,C | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 ddcc2020-qual-A                          OK                   [(Singular: X),(Singular: Y)] [('X', <class 'int'>), ('Y', <class 'int'>)]
 ddcc2020-qual-B                          OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-ddcc2020-qual-C                          No result
+ddcc2020-qual-C                          OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('s', <class 'str'>)]
 ddcc2020-qual-D                          OK                   [(Singular: M),(Parallel: d,c | 1 to M)] [('M', <class 'int'>), ('d', <class 'int'>), ('c', <class 'int'>)]
 ddcc2020-qual-F                          OK                   [(Singular: H),(Singular: W),(Singular: T)] [('H', <class 'int'>), ('W', <class 'int'>), ('T', <class 'int'>)]
 digitalarts2012-A                        No result
-digitalarts2012-B                        OK                   [(Parallel: c | 1 to 1)] [('c', <class 'str'>)]
+digitalarts2012-B                        OK                   [(Singular: c)] [('c', <class 'str'>)]
 discovery2016-final-A                    OK                   [(Singular: N),(Parallel: Id | 1 to N)] [('N', <class 'int'>), ('Id', <class 'int'>)]
 discovery2016-final-B                    OK                   [(Singular: N),(Singular: X),(Parallel: T | 1 to N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
 discovery2016-final-C                    OK                   [(Singular: S),(Singular: K)] [('S', <class 'str'>), ('K', <class 'int'>)]
@@ -5158,7 +5158,7 @@ dp-D                                     OK                   [(Singular: N),(Si
 dp-E                                     OK                   [(Singular: N),(Singular: W),(Parallel: w,v | 1 to N)] [('N', <class 'int'>), ('W', <class 'int'>), ('w', <class 'int'>), ('v', <class 'int'>)]
 dp-F                                     OK                   [(Singular: s),(Singular: t)] [('s', <class 'str'>), ('t', <class 'str'>)]
 dp-G                                     OK                   [(Singular: N),(Singular: M),(Parallel: x,y | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
-dp-H                                     OK                   [(Singular: H),(Singular: W),(TwoDimensional: a)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
+dp-H                                     OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 dp-I                                     OK                   [(Singular: N),(Parallel: p | 1 to N)] [('N', <class 'int'>), ('p', <class 'float'>)]
 dp-J                                     OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 dp-K                                     OK                   [(Singular: N),(Singular: K),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>)]
@@ -5275,7 +5275,7 @@ fps-24-O                                 OK                   [(Singular: N)] [(
 fps-24-P                                 OK                   [(Singular: N),(Singular: M),(Singular: K)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>)]
 fps-24-Q                                 OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A | 1 to N),(Parallel: B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 fps-24-R                                 OK                   [(Singular: N),(Singular: T),(Singular: X)] [('N', <class 'int'>), ('T', <class 'int'>), ('X', <class 'int'>)]
-fps-24-S                                 No result
+fps-24-S                                 OK                   [(Singular: U),(Singular: mathrmtype)] [('U', <class 'int'>), ('mathrmtype', <class 'int'>)]
 fps-24-T                                 OK                   [(Singular: N),(Singular: T),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
 fps-24-U                                 OK                   [(Singular: N),(Singular: U)] [('N', <class 'int'>), ('U', <class 'int'>)]
 fps-24-V                                 OK                   [(Singular: N),(Singular: H),(Singular: W)] [('N', <class 'int'>), ('H', <class 'int'>), ('W', <class 'int'>)]
@@ -5337,7 +5337,7 @@ highrate2025-parallel-A                  OK                   [(Singular: N),(Si
 highrate2025-parallel-B                  OK                   [(Singular: M)] [('M', <class 'int'>)]
 highrate2025-parallel-C                  OK                   [(Singular: N)] [('N', <class 'int'>)]
 highrate2025-parallel-D                  OK                   [(Singular: N)] [('N', <class 'str'>)]
-highrate2025-parallel-E                  No result
+highrate2025-parallel-E                  OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 hitachi2020-A                            OK                   [(Singular: S)] [('S', <class 'str'>)]
 hitachi2020-B                            OK                   [(Singular: A),(Singular: B),(Singular: M),(Parallel: a | 1 to A),(Parallel: b | 1 to B),(Parallel: x,y,c | 1 to M)] [('A', <class 'int'>), ('B', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('c', <class 'int'>)]
 hitachi2020-C                            OK                   [(Singular: N),(Parallel: a,b | 1 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
@@ -5360,7 +5360,7 @@ ijpc2015-C                               OK                   [(Singular: Q),(Pa
 ijpc2015-D                               No result
 ijpc2015-E                               No result
 indeednow-finala-open-A                  OK                   [(Singular: n),(Parallel: a | 1 to n)] [('n', <class 'int'>), ('a', <class 'int'>)]
-indeednow-finala-open-B                  No result
+indeednow-finala-open-B                  OK                   [(Singular: R),(Singular: C),(Parallel: a | 1 to R)] [('R', <class 'int'>), ('C', <class 'int'>), ('a', <class 'str'>)]
 indeednow-finala-open-C                  OK                   [(Singular: N),(Singular: M),(Parallel: a,b,c,w | 1 to N),(Parallel: x,y,z | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('w', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('z', <class 'int'>)]
 indeednow-finala-open-D                  OK                   [(Singular: n),(Parallel: a,b,t | 1 to n-1)] [('n', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('t', <class 'int'>)]
 indeednow-finala-open-E                  OK                   [(Singular: n),(Singular: m),(Parallel: a,b | 1 to m)] [('n', <class 'int'>), ('m', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
@@ -5437,15 +5437,15 @@ jag2013summer-day2-A                     OK                   [(Singular: N),(Si
 jag2013summer-day2-B                     OK                   [(Singular: W),(Parallel: a | 1 to W)] [('W', <class 'int'>), ('a', <class 'int'>)]
 jag2013summer-day2-C                     OK                   [(Singular: N),(Parallel: x,y,u,v | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
 jag2013summer-day2-D                     OK                   [(Singular: S),(Singular: N),(Singular: M),(Parallel: x | 1 to S),(Parallel: t,p | 1 to N)] [('S', <class 'int'>), ('N', <class 'int'>), ('M', <class 'int'>), ('x', <class 'int'>), ('t', <class 'int'>), ('p', <class 'int'>)]
-jag2013summer-day2-E                     No result
+jag2013summer-day2-E                     OK                   [(Singular: N),(Singular: M),(Singular: s),(Parallel: var,u | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('s', <class 'str'>), ('var', <class 'str'>), ('u', <class 'int'>)]
 jag2013summer-day2-F                     OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: a,b,c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
 jag2013summer-day4-A                     OK                   [(Singular: n),(Parallel: k,M | 1 to n)] [('n', <class 'int'>), ('k', <class 'int'>), ('M', <class 'str'>)]
 jag2013summer-day4-D                     OK                   [(Singular: N),(TwoDimensional: xLower),(TwoDimensional: xUpper)] [('N', <class 'int'>), ('xLower', <class 'int'>), ('xUpper', <class 'int'>)]
 jag2013summer-day4-E                     No result
 jag2013summer-day4-G                     No result
-jag2013summer-day4-H                     No result
+jag2013summer-day4-H                     OK                   [(Singular: H),(Singular: W),(Parallel: mA | 1 to 2),(Parallel: mB | 1 to 2),(Singular: mX),(Parallel: M | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('mA', <class 'int'>), ('mB', <class 'int'>), ('mX', <class 'int'>), ('M', <class 'str'>)]
 jag2013summer-day4-I                     No result
-jag2013summer-day4-J                     No result
+jag2013summer-day4-J                     OK                   [(Singular: W),(Parallel: s | 1 to 2),(Parallel: t | 1 to 2)] [('W', <class 'int'>), ('s', <class 'str'>), ('t', <class 'str'>)]
 jag2013summer-warmingup-C                OK                   [(Singular: H),(Singular: W),(TwoDimensional: u),(Parallel: f | 1 to W),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('u', <class 'int'>), ('f', <class 'int'>), ('s', <class 'int'>)]
 jag2015summer-day2-A                     OK                   [(Singular: p),(Singular: q)] [('p', <class 'int'>), ('q', <class 'int'>)]
 jag2015summer-day2-B                     OK                   [(Singular: N),(Singular: k)] [('N', <class 'int'>), ('k', <class 'int'>)]
@@ -5592,7 +5592,7 @@ joi2024yo1c-D                            OK                   [(Singular: K),(Si
 joi2024yo2-A                             OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 joi2024yo2-B                             OK                   [(Singular: N),(Singular: M),(Singular: Q),(Parallel: P,A | 1 to N),(Parallel: T,L,R | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('Q', <class 'int'>), ('P', <class 'int'>), ('A', <class 'int'>), ('T', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 joi2024yo2-C                             OK                   [(Singular: N),(Singular: S),(Singular: A),(Singular: B),(Singular: C)] [('N', <class 'int'>), ('S', <class 'str'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-joi2024yo2-D                             No result
+joi2024yo2-D                             OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'str'>)]
 joi2024yo2-E                             OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A,B,L,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('L', <class 'int'>), ('C', <class 'int'>)]
 joi2025ho-A                              OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 joi2025ho-B                              OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
@@ -5664,7 +5664,7 @@ joig2022-open-F                          OK                   [(Singular: N),(Si
 joig2023-open-A                          OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 joig2023-open-B                          OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 joig2023-open-C                          OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: A | 1 to N),(Parallel: B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-joig2023-open-D                          No result
+joig2023-open-D                          OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 joig2023-open-E                          OK                   [(Singular: H),(Singular: W),(TwoDimensional: A)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>)]
 joig2023-open-F                          OK                   [(Singular: N),(Singular: S),(Singular: Q),(Parallel: A,L,R | 1 to Q)] [('N', <class 'int'>), ('S', <class 'str'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 joig2024-open-A                          OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
@@ -5793,7 +5793,7 @@ judge-update-202004-B                    OK                   [(Singular: N),(Pa
 judge-update-202004-C                    OK                   [(Parallel: a | 1 to 3)] [('a', <class 'int'>)]
 judge-update-202004-D                    OK                   [(Singular: N),(Singular: Q),(Parallel: A | 1 to N),(Parallel: S | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('S', <class 'int'>)]
 k2pc-easy-A                              OK                   [(Singular: a),(Singular: b),(Singular: c),(Singular: N)] [('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('N', <class 'int'>)]
-k2pc-easy-B                              No result
+k2pc-easy-B                              OK                   [(Singular: N),(Parallel: a | 1 to 10),(Parallel: c | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>), ('c', <class 'str'>)]
 k2pc-easy-C                              OK                   [(Singular: i),(Singular: j)] [('i', <class 'int'>), ('j', <class 'int'>)]
 k2pc-easy-D                              OK                   [(Singular: K),(Singular: N),(Parallel: p,q | 1 to N)] [('K', <class 'int'>), ('N', <class 'int'>), ('p', <class 'int'>), ('q', <class 'int'>)]
 k2pc-easy-E                              OK                   [(Singular: n)] [('n', <class 'int'>)]
@@ -5828,11 +5828,11 @@ keyence2021-D                            OK                   [(Singular: N)] [(
 keyence2021-E                            OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 keyence2021-F                            OK                   [(Singular: N),(Singular: t)] [('N', <class 'int'>), ('t', <class 'str'>)]
 kupc2012-A                               OK                   [(Singular: N),(Singular: T),(Singular: E),(Parallel: x | 1 to N)] [('N', <class 'int'>), ('T', <class 'int'>), ('E', <class 'int'>), ('x', <class 'int'>)]
-kupc2012-B                               No result
+kupc2012-B                               OK                   [(Singular: c)] [('c', <class 'str'>)]
 kupc2012-C                               No result
-kupc2012-D                               No result
+kupc2012-D                               OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 kupc2012-F                               OK                   [(Singular: N),(Singular: Q),(Parallel: w,t,x | 1 to N),(Parallel: y | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('w', <class 'int'>), ('t', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
-kupc2012-G                               No result
+kupc2012-G                               OK                   [(Singular: N),(Singular: R),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('R', <class 'float'>), ('x', <class 'float'>), ('y', <class 'float'>)]
 kupc2012-I                               No result
 kupc2012-J                               No result
 kupc2012-K                               OK                   [(Singular: N),(Singular: M),(Singular: Q),(Parallel: f,t,p | 1 to M),(Parallel: a,b | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('Q', <class 'int'>), ('f', <class 'int'>), ('t', <class 'int'>), ('p', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
@@ -5887,11 +5887,11 @@ kupc2017-F                               OK                   [(Singular: N),(Pa
 kupc2017-G                               No result
 kupc2017-H                               OK                   [(Singular: n),(Singular: m),(Parallel: v | 1 to n),(Parallel: h | 1 to n),(Parallel: a,x,b,y | 1 to m)] [('n', <class 'int'>), ('m', <class 'int'>), ('v', <class 'int'>), ('h', <class 'int'>), ('a', <class 'int'>), ('x', <class 'int'>), ('b', <class 'int'>), ('y', <class 'int'>)]
 kupc2017-I                               OK                   [(Singular: n),(Singular: m),(Singular: k),(Parallel: x | 1 to k),(Parallel: l,r | 1 to m)] [('n', <class 'int'>), ('m', <class 'int'>), ('k', <class 'int'>), ('x', <class 'int'>), ('l', <class 'int'>), ('r', <class 'int'>)]
-kupc2017-J                               No result
+kupc2017-J                               OK                   [(Singular: H),(Singular: W),(Parallel: a | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('a', <class 'str'>)]
 kupc2017-K                               OK                   [(Singular: n),(Singular: m),(Singular: k)] [('n', <class 'int'>), ('m', <class 'int'>), ('k', <class 'int'>)]
-kupc2017-L                               No result
+kupc2017-L                               OK                   [(Singular: H),(Singular: W),(Parallel: m | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('m', <class 'str'>)]
 kupc2018-A                               OK                   [(Singular: N),(Parallel: s | 1 to N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('s', <class 'int'>), ('a', <class 'int'>)]
-kupc2018-B                               No result
+kupc2018-B                               OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 kupc2018-E                               OK                   [(Singular: N),(Parallel: p | 1 to N)] [('N', <class 'int'>), ('p', <class 'int'>)]
 kupc2018-F                               OK                   [(Singular: N),(Singular: M),(Parallel: s | 1 to N),(Parallel: a,b,c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('s', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
 kupc2018-G                               OK                   [(Singular: N),(Singular: M),(Parallel: c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('c', <class 'int'>)]
@@ -5920,7 +5920,7 @@ kupc2020-D                               OK                   [(Singular: N)] [(
 kupc2020-E                               OK                   [(Singular: N),(Parallel: a | 0 to N-1),(Parallel: b | 0 to N-1),(Parallel: c | 0 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
 kupc2020-F                               OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H-1),(Parallel: B | 1 to W),(Parallel: C | 1 to H),(Parallel: D | 1 to W-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 kupc2020-G                               OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
-kupc2020-H                               No result
+kupc2020-H                               OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 kupc2020-I                               OK                   [(Singular: N),(Singular: M),(Parallel: u,v | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
 kupc2020-K                               OK                   [(Parallel: N | 1 to 2),(Singular: M),(Parallel: a,b | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 kupc2020-L                               No result
@@ -5952,13 +5952,13 @@ kupc2024-M                               OK                   [(Singular: N),(Si
 kupc2024-N                               OK                   [(Singular: N)] [('N', <class 'int'>)]
 kupc2024-O                               OK                   [(Singular: N),(Parallel: A,B | 1 to N-1),(Parallel: W | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('W', <class 'int'>)]
 kupc2024-P                               OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
-language-test-ver1-A                     No result
+language-test-ver1-A                     OK                   [(Singular: N),(Singular: c)] [('N', <class 'int'>), ('c', <class 'str'>)]
 language-test-ver1-B                     OK                   [(Singular: X),(Singular: s)] [('X', <class 'str'>), ('s', <class 'str'>)]
 language-test-ver1-C                     OK                   [(Parallel: b | 0 to 9),(Singular: N),(Parallel: a | 0 to N-1)] [('b', <class 'int'>), ('N', <class 'int'>), ('a', <class 'int'>)]
 language-test-ver1-D                     No result
 language-test-ver1-E                     No result
 language-test-ver1-F                     OK                   [(Singular: N),(Parallel: x,y,t,r | 0 to N-1)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('t', <class 'int'>), ('r', <class 'int'>)]
-language-test-ver1-G                     No result
+language-test-ver1-G                     OK                   [(Singular: H),(Singular: W),(Parallel: c | 0 to H-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 m-solutions2019-A                        OK                   [(Singular: N)] [('N', <class 'int'>)]
 m-solutions2019-B                        OK                   [(Singular: S)] [('S', <class 'str'>)]
 m-solutions2019-C                        OK                   [(Singular: N),(Singular: A),(Singular: B),(Singular: C)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
@@ -6013,15 +6013,15 @@ mujin-pc-2017-C                          OK                   [(Singular: s),(Si
 mujin-pc-2017-D                          OK                   [(Singular: N),(Parallel: a,b | 1 to N-1)] [('N', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 mujin-pc-2018-A                          OK                   [(Singular: S)] [('S', <class 'str'>)]
 mujin-pc-2018-B                          OK                   [(Singular: A),(Singular: S)] [('A', <class 'int'>), ('S', <class 'str'>)]
-mujin-pc-2018-C                          No result
+mujin-pc-2018-C                          OK                   [(Singular: N),(Singular: M),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('s', <class 'str'>)]
 mujin-pc-2018-D                          OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
-mujin-pc-2018-E                          No result
+mujin-pc-2018-E                          OK                   [(Singular: N),(Singular: M),(Singular: K),(Singular: d),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('d', <class 'str'>), ('s', <class 'str'>)]
 mujin-pc-2018-F                          OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 mujin-pc-2018-G                          OK                   [(Singular: Q),(Parallel: a,b,c,d,e,f,k | 1 to Q)] [('Q', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>), ('d', <class 'int'>), ('e', <class 'int'>), ('f', <class 'int'>), ('k', <class 'int'>)]
 mujin-pc-2018-H                          OK                   [(Singular: H),(Singular: W)] [('H', <class 'int'>), ('W', <class 'int'>)]
 nadafes2022_day1-A                       OK                   [(Singular: N)] [('N', <class 'int'>)]
 nadafes2022_day1-B                       OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
-nadafes2022_day1-C                       OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: A | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('A', <class 'str'>)]
+nadafes2022_day1-C                       OK                   [(Singular: H),(Singular: W),(Singular: K),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>), ('A', <class 'str'>)]
 nadafes2022_day1-D                       OK                   [(Singular: N)] [('N', <class 'int'>)]
 nadafes2022_day1-E                       OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: B,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 nadafes2022_day1-F                       OK                   [(Singular: N),(Singular: M),(Singular: K)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>)]
@@ -6037,7 +6037,7 @@ nadafes2022_day1-O                       OK                   [(Singular: N),(Si
 nadafes2022_day1-P                       OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 nadafes2022_day2-A                       OK                   [(Singular: N),(Singular: K),(Singular: M)] [('N', <class 'int'>), ('K', <class 'int'>), ('M', <class 'int'>)]
 nadafes2022_day2-B                       OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-nadafes2022_day2-C                       No result
+nadafes2022_day2-C                       OK                   [(Singular: H),(Singular: W),(Singular: N),(Parallel: C,D,S,T | 1 to N),(Parallel: G | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>), ('G', <class 'str'>)]
 nadafes2022_day2-E                       OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 nadafes2022_day2-F                       OK                   [(Singular: N),(Parallel: S,T,A,B | 1 to N)] [('N', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 nadafes2022_day2-G                       OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
@@ -6158,7 +6158,7 @@ nupc2024-K                               No result
 nupc2024-L                               OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: W | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('W', <class 'int'>)]
 nupc2024-M                               OK                   [(Singular: N),(Singular: M),(Parallel: u,v | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
 nupc2024-N                               OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N),(Parallel: u,v | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>)]
-nupc2024-O                               No result
+nupc2024-O                               OK                   [(Singular: N),(Singular: M),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'str'>)]
 nupc2024-P                               No result
 nupc2024-Q                               OK                   [(Singular: N)] [('N', <class 'int'>)]
 oidashi-A                                OK                   [(Singular: H),(Singular: W),(Parallel: line | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('line', <class 'str'>)]
@@ -6212,8 +6212,8 @@ pakencamp-2019-day2-A                    No result
 pakencamp-2019-day3-A                    OK                   [(Singular: A),(Singular: B)] [('A', <class 'int'>), ('B', <class 'int'>)]
 pakencamp-2019-day3-B                    OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 pakencamp-2019-day3-C                    OK                   [(Singular: N),(Singular: M),(TwoDimensional: A)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
-pakencamp-2019-day3-D                    No result
-pakencamp-2019-day3-E                    No result
+pakencamp-2019-day3-D                    OK                   [(Singular: N),(Parallel: S | 1 to 5)] [('N', <class 'int'>), ('S', <class 'str'>)]
+pakencamp-2019-day3-E                    OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H),(Singular: Q),(Parallel: X,Y,L | 1 to Q)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>), ('Q', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('L', <class 'int'>)]
 pakencamp-2019-day3-F                    OK                   [(Singular: N),(Parallel: A | 1 to N),(Singular: Q),(Parallel: X,Y | 1 to Q)] [('N', <class 'int'>), ('A', <class 'int'>), ('Q', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 pakencamp-2019-day3-G                    OK                   [(Singular: N),(Parallel: A | 1 to N),(Singular: M),(Parallel: B | 1 to M),(Singular: Q),(Parallel: T,C,D | 1 to Q)] [('N', <class 'int'>), ('A', <class 'int'>), ('M', <class 'int'>), ('B', <class 'int'>), ('Q', <class 'int'>), ('T', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 pakencamp-2019-day3-H                    No result
@@ -6223,7 +6223,7 @@ pakencamp-2019-day4-C                    OK                   [(Parallel: L,R | 
 pakencamp-2019-day4-D                    OK                   [(Singular: N),(Singular: X)] [('N', <class 'int'>), ('X', <class 'int'>)]
 pakencamp-2019-day4-E                    OK                   [(Singular: N),(Singular: M),(Parallel: A,B,S,W | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('S', <class 'int'>), ('W', <class 'int'>)]
 pakencamp-2019-day4-F                    OK                   [(Singular: N),(Singular: K),(Parallel: A,B,C | 1 to N-1),(Singular: Q),(Parallel: S,T | 1 to Q)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('Q', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>)]
-pakencamp-2019-day4-G                    No result
+pakencamp-2019-day4-G                    OK                   [(Singular: n),(Singular: a),(Singular: m),(Singular: p),(Singular: t),(Singular: K),(Singular: s)] [('n', <class 'int'>), ('a', <class 'int'>), ('m', <class 'int'>), ('p', <class 'int'>), ('t', <class 'int'>), ('K', <class 'int'>), ('s', <class 'str'>)]
 pakencamp-2020-day1-A                    No result
 pakencamp-2020-day1-B                    OK                   [(Singular: X)] [('X', <class 'int'>)]
 pakencamp-2020-day1-C                    No result
@@ -6240,7 +6240,7 @@ pakencamp-2020-day1-M                    No result
 pakencamp-2020-day1-N                    No result
 pakencamp-2020-day1-O                    No result
 pakencamp-2020-day2-A                    No result
-pakencamp-2020-day2-B                    No result
+pakencamp-2020-day2-B                    OK                   [(Singular: H),(Singular: W),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('C', <class 'str'>)]
 pakencamp-2020-day2-C                    No result
 pakencamp-2020-day2-D                    No result
 pakencamp-2020-day2-E                    No result
@@ -6478,7 +6478,7 @@ past17-open-C                            OK                   [(Singular: N),(Pa
 past17-open-D                            OK                   [(Singular: A),(Singular: B),(Singular: C),(Parallel: x | 1 to 12)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('x', <class 'int'>)]
 past17-open-E                            OK                   [(Singular: S)] [('S', <class 'str'>)]
 past17-open-F                            OK                   [(Singular: N),(Parallel: p | 2 to N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('p', <class 'int'>), ('S', <class 'str'>)]
-past17-open-G                            No result
+past17-open-G                            OK                   [(Singular: H),(Singular: W),(Parallel: G | 1 to H),(Singular: N),(Singular: S)] [('H', <class 'int'>), ('W', <class 'int'>), ('G', <class 'str'>), ('N', <class 'int'>), ('S', <class 'str'>)]
 past17-open-H                            OK                   [(Singular: N),(Singular: M),(Parallel: a,b,c | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
 past17-open-I                            OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 past17-open-J                            OK                   [(Singular: N),(Parallel: A,B | 1 to N),(Singular: Q),(Parallel: t | 1 to Q)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('Q', <class 'int'>), ('t', <class 'int'>)]
@@ -6496,7 +6496,7 @@ past18-open-F                            No result
 past18-open-G                            OK                   [(Singular: N),(Parallel: A | 1 to N),(Parallel: B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 past18-open-H                            OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 past18-open-I                            No result
-past18-open-J                            No result
+past18-open-J                            OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 past18-open-K                            OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 past18-open-L                            OK                   [(Singular: N),(Singular: Q),(Parallel: s,p | 1 to N),(Parallel: q | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('s', <class 'str'>), ('p', <class 'int'>), ('q', <class 'int'>)]
 past18-open-M                            OK                   [(Singular: N),(Singular: M),(Singular: S),(Parallel: A | 1 to N),(Parallel: X,Y | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'int'>), ('A', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
@@ -6549,13 +6549,13 @@ past201912-open-N                        OK                   [(Singular: N),(Si
 past201912-open-O                        OK                   [(Singular: N),(TwoDimensional: A)] [('N', <class 'int'>), ('A', <class 'int'>)]
 past202004-open-A                        OK                   [(Singular: S),(Singular: T)] [('S', <class 'str'>), ('T', <class 'str'>)]
 past202004-open-B                        OK                   [(Singular: S)] [('S', <class 'str'>)]
-past202004-open-C                        No result
+past202004-open-C                        OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 past202004-open-D                        OK                   [(Singular: S)] [('S', <class 'str'>)]
 past202004-open-E                        OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 past202004-open-F                        OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 past202004-open-G                        No result
-past202004-open-H                        No result
-past202004-open-I                        No result
+past202004-open-H                        OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'str'>)]
+past202004-open-I                        OK                   [(Singular: N),(Parallel: A | 1 to 2^N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 past202004-open-J                        OK                   [(Singular: S)] [('S', <class 'str'>)]
 past202004-open-K                        OK                   [(Singular: N),(Singular: S),(Parallel: C | 1 to N),(Parallel: D | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 past202004-open-L                        OK                   [(Singular: N),(Singular: K),(Singular: D),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('D', <class 'int'>), ('A', <class 'int'>)]
@@ -6567,7 +6567,7 @@ past202005-open-B                        No result
 past202005-open-C                        OK                   [(Singular: A),(Singular: R),(Singular: N)] [('A', <class 'int'>), ('R', <class 'int'>), ('N', <class 'int'>)]
 past202005-open-D                        OK                   [(Singular: N),(Parallel: s | 1 to 5)] [('N', <class 'int'>), ('s', <class 'str'>)]
 past202005-open-E                        No result
-past202005-open-F                        OK                   [(Singular: N),(Parallel: a | 1 to 2)] [('N', <class 'int'>), ('a', <class 'str'>)]
+past202005-open-F                        OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'str'>)]
 past202005-open-G                        OK                   [(Singular: N),(Singular: X),(Singular: Y),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 past202005-open-H                        OK                   [(Singular: N),(Singular: L),(Parallel: x | 1 to N),(Parallel: T | 1 to 3)] [('N', <class 'int'>), ('L', <class 'int'>), ('x', <class 'int'>), ('T', <class 'int'>)]
 past202005-open-I                        No result
@@ -6579,27 +6579,27 @@ past202005-open-N                        OK                   [(Singular: N),(Si
 past202005-open-O                        OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: B | 1 to N),(Parallel: R | 1 to 3)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('R', <class 'int'>)]
 past202010-open-A                        OK                   [(Singular: A),(Singular: B),(Singular: C)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 past202010-open-B                        OK                   [(Singular: X),(Singular: Y)] [('X', <class 'int'>), ('Y', <class 'int'>)]
-past202010-open-C                        No result
+past202010-open-C                        OK                   [(Singular: N),(Singular: M),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('s', <class 'str'>)]
 past202010-open-D                        OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 past202010-open-E                        OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 past202010-open-F                        No result
 past202010-open-G                        No result
-past202010-open-H                        No result
+past202010-open-H                        OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: s | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('s', <class 'str'>)]
 past202010-open-I                        OK                   [(Singular: N),(Parallel: a | 1 to N)] [('N', <class 'int'>), ('a', <class 'int'>)]
 past202010-open-J                        No result
 past202010-open-K                        No result
 past202010-open-L                        No result
 past202010-open-M                        OK                   [(Singular: N),(Singular: Q),(Parallel: a,b | 1 to N-1),(Parallel: u,v,c | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('u', <class 'int'>), ('v', <class 'int'>), ('c', <class 'int'>)]
-past202010-open-N                        No result
+past202010-open-N                        OK                   [(Parallel: s | 1 to 18)] [('s', <class 'str'>)]
 past202010-open-O                        No result
-past202012-open-A                        No result
+past202012-open-A                        OK                   [(Singular: S)] [('S', <class 'str'>)]
 past202012-open-B                        OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
 past202012-open-C                        OK                   [(Singular: N)] [('N', <class 'int'>)]
 past202012-open-D                        OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 past202012-open-E                        No result
 past202012-open-F                        No result
 past202012-open-G                        No result
-past202012-open-H                        No result
+past202012-open-H                        OK                   [(Singular: H),(Singular: W),(Singular: r),(Singular: c),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('r', <class 'int'>), ('c', <class 'int'>), ('s', <class 'str'>)]
 past202012-open-I                        No result
 past202012-open-J                        OK                   [(Singular: S),(Singular: X)] [('S', <class 'str'>), ('X', <class 'int'>)]
 past202012-open-K                        OK                   [(Parallel: S | 1 to 4)] [('S', <class 'str'>)]
@@ -6647,11 +6647,11 @@ past202109-open-G                        OK                   [(Singular: N),(Si
 past202109-open-H                        OK                   [(Singular: N),(Singular: X),(Parallel: a,b,c | 1 to N-1)] [('N', <class 'int'>), ('X', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
 past202109-open-I                        OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 past202109-open-J                        OK                   [(Singular: N),(Singular: Q),(Parallel: t,k | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('t', <class 'int'>), ('k', <class 'int'>)]
-past202109-open-K                        No result
+past202109-open-K                        OK                   [(Singular: P),(Singular: Q),(Parallel: S | 1 to P),(Parallel: A,B | 1 to P),(Parallel: C,D | 1 to Q)] [('P', <class 'int'>), ('Q', <class 'int'>), ('S', <class 'str'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 past202109-open-L                        OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 past202109-open-M                        OK                   [(Singular: N),(Singular: M),(Parallel: A,B,C | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 past202109-open-N                        OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-past202109-open-O                        No result
+past202109-open-O                        OK                   [(Singular: N),(Singular: M),(Parallel: P | 1 to 2^N),(Parallel: W,L | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('P', <class 'int'>), ('W', <class 'int'>), ('L', <class 'int'>)]
 past202112-open-A                        OK                   [(Singular: H),(Singular: W),(Singular: h),(Singular: w)] [('H', <class 'int'>), ('W', <class 'int'>), ('h', <class 'int'>), ('w', <class 'int'>)]
 past202112-open-B                        OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 past202112-open-C                        OK                   [(Singular: N),(Parallel: P,V | 1 to N)] [('N', <class 'int'>), ('P', <class 'str'>), ('V', <class 'str'>)]
@@ -6669,7 +6669,7 @@ past202112-open-N                        OK                   [(Singular: N),(Si
 past202112-open-O                        OK                   [(Singular: N),(Parallel: B | 1 to N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('B', <class 'int'>), ('S', <class 'int'>)]
 past202203-open-A                        OK                   [(Singular: A),(Singular: B),(Singular: C)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
 past202203-open-B                        OK                   [(Singular: A),(Singular: B),(Singular: X),(Singular: Y)] [('A', <class 'int'>), ('B', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
-past202203-open-C                        No result
+past202203-open-C                        OK                   [(Singular: alpha)] [('alpha', <class 'str'>)]
 past202203-open-D                        OK                   [(Singular: T),(Singular: N),(TwoDimensional: P)] [('T', <class 'int'>), ('N', <class 'int'>), ('P', <class 'int'>)]
 past202203-open-E                        OK                   [(Singular: S)] [('S', <class 'str'>)]
 past202203-open-F                        OK                   [(Singular: H),(Singular: W),(Singular: N),(TwoDimensional: A),(Parallel: C | 1 to N)] [('H', <class 'int'>), ('W', <class 'int'>), ('N', <class 'int'>), ('A', <class 'int'>), ('C', <class 'int'>)]
@@ -6690,7 +6690,7 @@ past202206-open-E                        OK                   [(Singular: N)] [(
 past202206-open-F                        OK                   [(Singular: H),(Singular: W),(TwoDimensional: S),(Singular: N),(Parallel: r,c | 1 to N)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'int'>), ('N', <class 'int'>), ('r', <class 'int'>), ('c', <class 'int'>)]
 past202206-open-G                        OK                   [(Singular: N),(Parallel: A,B | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 past202206-open-H                        OK                   [(Singular: N),(Singular: A),(Singular: B),(Parallel: w,v | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('w', <class 'int'>), ('v', <class 'int'>)]
-past202206-open-I                        OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+past202206-open-I                        OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 past202206-open-J                        OK                   [(Singular: S),(Singular: T)] [('S', <class 'str'>), ('T', <class 'str'>)]
 past202206-open-K                        OK                   [(Singular: S),(Singular: T)] [('S', <class 'str'>), ('T', <class 'str'>)]
 past202206-open-L                        OK                   [(Singular: S),(Singular: T),(Singular: K)] [('S', <class 'str'>), ('T', <class 'str'>), ('K', <class 'int'>)]
@@ -6711,17 +6711,17 @@ past202209-open-K                        OK                   [(Singular: N),(Si
 past202209-open-L                        OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: P,Q,L,R | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('P', <class 'int'>), ('Q', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 past202209-open-M                        OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N),(Parallel: B,L,R | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 past202209-open-N                        No result
-past202209-open-O                        No result
+past202209-open-O                        OK                   [(Singular: N),(Singular: Q),(Parallel: A | 0 to 2^N-1),(Parallel: B | 0 to 2^N-1),(Parallel: X,Y | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 past202212-open-A                        OK                   [(Singular: N),(Singular: X),(Singular: Y)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
 past202212-open-B                        OK                   [(Singular: A),(Singular: B),(Singular: C),(Singular: D)] [('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
 past202212-open-C                        OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-past202212-open-D                        No result
+past202212-open-D                        OK                   [(Singular: N),(Singular: M),(Singular: S)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'str'>)]
 past202212-open-E                        OK                   [(Singular: S)] [('S', <class 'str'>)]
 past202212-open-F                        OK                   [(Singular: N),(Singular: A),(Singular: B),(Singular: C),(Singular: D),(Singular: X)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>), ('X', <class 'float'>)]
 past202212-open-G                        OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 past202212-open-H                        OK                   [(Singular: D),(Singular: N)] [('D', <class 'int'>), ('N', <class 'str'>)]
 past202212-open-I                        OK                   [(Singular: N),(Singular: M),(Parallel: A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-past202212-open-J                        No result
+past202212-open-J                        OK                   [(Singular: N),(Singular: K),(Singular: x_mathrms),(Singular: y_mathrms),(Singular: x_mathrmt),(Singular: y_mathrmt),(Parallel: P,Q,R,W | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('x_mathrms', <class 'int'>), ('y_mathrms', <class 'int'>), ('x_mathrmt', <class 'int'>), ('y_mathrmt', <class 'int'>), ('P', <class 'int'>), ('Q', <class 'int'>), ('R', <class 'int'>), ('W', <class 'int'>)]
 past202212-open-K                        OK                   [(Singular: A),(Singular: B),(Singular: X)] [('A', <class 'int'>), ('B', <class 'int'>), ('X', <class 'int'>)]
 past202212-open-L                        OK                   [(Singular: N),(Parallel: L,R | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 past202212-open-M                        OK                   [(Singular: N),(Parallel: U,V | 1 to N-1)] [('N', <class 'int'>), ('U', <class 'int'>), ('V', <class 'int'>)]
@@ -6789,7 +6789,7 @@ past23-open-N                            OK                   [(Singular: N),(Si
 past23-open-O                            OK                   [(Singular: H),(Singular: W),(Singular: D),(TwoDimensional: A)] [('H', <class 'int'>), ('W', <class 'int'>), ('D', <class 'int'>), ('A', <class 'int'>)]
 qupc2014-A                               No result
 qupc2014-B                               OK                   [(Singular: N)] [('N', <class 'int'>)]
-qupc2014-C                               No result
+qupc2014-C                               OK                   [(Singular: N),(Singular: M),(Singular: Q),(Parallel: s | 1 to N),(Parallel: q | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('Q', <class 'int'>), ('s', <class 'str'>), ('q', <class 'str'>)]
 qupc2014-D                               OK                   [(Singular: N),(Singular: M),(Singular: K),(Singular: S),(Singular: G),(Parallel: a,b,d | 0 to M-1),(Parallel: x,f | 0 to K-1)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('S', <class 'int'>), ('G', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('d', <class 'int'>), ('x', <class 'int'>), ('f', <class 'int'>)]
 qupc2014-E                               No result
 qupc2014-F                               OK                   [(Singular: N),(Singular: T),(Singular: M),(Parallel: D | 0 to N-1)] [('N', <class 'int'>), ('T', <class 'int'>), ('M', <class 'int'>), ('D', <class 'int'>)]
@@ -6797,7 +6797,7 @@ qupc2014-G                               OK                   [(Singular: N),(Si
 qupc2014-H                               OK                   [(Singular: N),(Singular: M),(Singular: P),(Singular: G),(Parallel: L | 0 to G-1),(Parallel: from,to,cap | 0 to N-1)] [('N', <class 'int'>), ('M', <class 'int'>), ('P', <class 'int'>), ('G', <class 'int'>), ('L', <class 'int'>), ('from', <class 'int'>), ('to', <class 'int'>), ('cap', <class 'int'>)]
 qupc2018-A                               OK                   [(Singular: N)] [('N', <class 'int'>)]
 qupc2018-B                               OK                   [(Singular: Q),(Parallel: A,B,C | 1 to Q)] [('Q', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-qupc2018-C                               No result
+qupc2018-C                               OK                   [(Singular: H),(Singular: W),(Singular: X),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('X', <class 'int'>), ('s', <class 'str'>)]
 qupc2018-D                               OK                   [(Singular: N),(Singular: M),(Singular: L),(Parallel: T | 1 to N),(Parallel: X,A | 1 to M),(Parallel: Y,B | 1 to L)] [('N', <class 'int'>), ('M', <class 'int'>), ('L', <class 'int'>), ('T', <class 'int'>), ('X', <class 'int'>), ('A', <class 'int'>), ('Y', <class 'int'>), ('B', <class 'int'>)]
 qupc2018-E                               OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 qupc2018-F                               OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
@@ -6849,16 +6849,16 @@ s8pc-5-A                                 OK                   [(Singular: N),(Si
 s8pc-5-B                                 No result
 s8pc-5-C                                 OK                   [(Singular: Q),(Parallel: S | 1 to Q)] [('Q', <class 'int'>), ('S', <class 'str'>)]
 s8pc-5-D                                 OK                   [(Singular: H),(Singular: W)] [('H', <class 'str'>), ('W', <class 'str'>)]
-s8pc-5-E                                 No result
+s8pc-5-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 s8pc-5-F                                 OK                   [(Singular: N),(Singular: M),(Singular: Q),(Parallel: a | 1 to N),(Parallel: l,r | 1 to Q)] [('N', <class 'int'>), ('M', <class 'int'>), ('Q', <class 'int'>), ('a', <class 'int'>), ('l', <class 'int'>), ('r', <class 'int'>)]
 s8pc-5-G                                 OK                   [(Singular: S)] [('S', <class 'str'>)]
 s8pc-5-H                                 OK                   [(Singular: S),(Singular: Q),(Parallel: K,p | 1 to Q)] [('S', <class 'str'>), ('Q', <class 'int'>), ('K', <class 'int'>), ('p', <class 'int'>)]
 s8pc-6-A                                 OK                   [(Singular: N),(Singular: T),(Parallel: A | 1 to N-1)] [('N', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>)]
 s8pc-6-B                                 OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
-s8pc-6-C                                 No result
+s8pc-6-C                                 OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 s8pc-6-D                                 OK                   [(Singular: N),(Parallel: X,R | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('R', <class 'int'>)]
-s8pc-6-E                                 No result
-s8pc-6-F                                 No result
+s8pc-6-E                                 OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+s8pc-6-F                                 OK                   [(Singular: N),(Singular: D),(Singular: L),(Singular: S)] [('N', <class 'int'>), ('D', <class 'int'>), ('L', <class 'int'>), ('S', <class 'str'>)]
 s8pc-6-G                                 OK                   [(Singular: N),(Singular: P),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>), ('A', <class 'int'>)]
 s8pc-6-H                                 OK                   [(Singular: Q),(Parallel: K | 1 to Q)] [('Q', <class 'int'>), ('K', <class 'int'>)]
 s8pc-6-I                                 OK                   [(Singular: H),(Singular: W),(TwoDimensional: A)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>)]
@@ -6898,7 +6898,7 @@ scpc2026-div3-I                          No result
 scpc2026-div3-J                          OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
 soundhound2018-A                         OK                   [(Singular: X),(Singular: Y)] [('X', <class 'str'>), ('Y', <class 'str'>)]
 soundhound2018-B                         OK                   [(Singular: n),(Singular: L),(Singular: R),(Parallel: a | 1 to n)] [('n', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>), ('a', <class 'int'>)]
-soundhound2018-C                         No result
+soundhound2018-C                         OK                   [(Singular: r),(Singular: c),(Parallel: C | 1 to r)] [('r', <class 'int'>), ('c', <class 'int'>), ('C', <class 'str'>)]
 soundhound2018-D                         OK                   [(Singular: H),(Singular: W),(TwoDimensional: P),(TwoDimensional: F)] [('H', <class 'int'>), ('W', <class 'int'>), ('P', <class 'int'>), ('F', <class 'int'>)]
 soundhound2018-E                         OK                   [(Singular: N),(Singular: Q),(Singular: S),(Parallel: k | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('S', <class 'str'>), ('k', <class 'int'>)]
 soundhound2018-summer-final-A            OK                   [(Singular: C),(Singular: D)] [('C', <class 'int'>), ('D', <class 'int'>)]
@@ -6924,7 +6924,7 @@ stpc2025_1-D                             OK                   [(Singular: N),(Si
 stpc2025_1-E                             OK                   [(Singular: N),(Singular: Q),(Parallel: A | 1 to N),(Parallel: L,R | 1 to Q)] [('N', <class 'int'>), ('Q', <class 'int'>), ('A', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 stpc2025_1-F                             OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'int'>)]
 stpc2025_1-H                             OK                   [(Singular: H),(Singular: W),(Singular: A),(Singular: B),(Singular: C),(Singular: D)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
-stpc2025_1-I                             No result
+stpc2025_1-I                             OK                   [(Singular: N),(Parallel: S | 1 to 2*N+1),(Singular: Q),(Parallel: U,D,L,R | 1 to Q)] [('N', <class 'int'>), ('S', <class 'str'>), ('Q', <class 'int'>), ('U', <class 'int'>), ('D', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 stpc2025_1-J                             OK                   [(Singular: N),(Singular: M),(Parallel: S | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('S', <class 'int'>)]
 stpc2025_1-K                             No result
 stpc2025_1-L                             OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: x,y,c | 1 to N)]] [('T', <class 'int'>)]
@@ -6937,7 +6937,7 @@ stpc2025_2-E                             OK                   [(Singular: N),(Si
 stpc2025_2-F                             OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'int'>)]
 stpc2025_2-G                             OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: A),(Singular: B),(Singular: L),(Singular: R)]] [('T', <class 'int'>)]
 stpc2025_2-H                             OK                   [(Singular: H),(Singular: W),(Singular: A),(Singular: B),(Singular: C),(Singular: D)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>), ('D', <class 'int'>)]
-stpc2025_2-I                             No result
+stpc2025_2-I                             OK                   [(Singular: N),(Parallel: S | 1 to 2*N+1),(Singular: Q),(Parallel: U,D,L,R | 1 to Q)] [('N', <class 'int'>), ('S', <class 'str'>), ('Q', <class 'int'>), ('U', <class 'int'>), ('D', <class 'int'>), ('L', <class 'int'>), ('R', <class 'int'>)]
 stpc2025_2-J                             OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: R,C,H | 1 to N)]] [('T', <class 'int'>)]
 stpc2025_2-K                             No result
 stpc2025_2-L                             OK                   [(Singular: N),(Singular: M),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
@@ -6952,7 +6952,7 @@ sumitrust2019-E                          OK                   [(Singular: N),(Pa
 sumitrust2019-F                          OK                   [(Parallel: T | 1 to 2),(Parallel: A | 1 to 2),(Parallel: B | 1 to 2)] [('T', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 tdpc-A                                   OK                   [(Singular: N),(Parallel: p | 1 to N)] [('N', <class 'int'>), ('p', <class 'int'>)]
 tdpc-B                                   OK                   [(Singular: A),(Singular: B),(Parallel: a | 1 to A),(Parallel: b | 1 to B)] [('A', <class 'int'>), ('B', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
-tdpc-C                                   No result
+tdpc-C                                   OK                   [(Singular: K),(Parallel: R | 1 to 2^K)] [('K', <class 'int'>), ('R', <class 'int'>)]
 tdpc-D                                   OK                   [(Singular: N),(Singular: D)] [('N', <class 'int'>), ('D', <class 'int'>)]
 tdpc-E                                   OK                   [(Singular: D),(Singular: N)] [('D', <class 'int'>), ('N', <class 'str'>)]
 tdpc-F                                   OK                   [(Singular: N),(Singular: K)] [('N', <class 'int'>), ('K', <class 'int'>)]
@@ -6980,7 +6980,7 @@ tenka1-2012-qualA-B                      No result
 tenka1-2012-qualA-C                      OK                   [(Singular: N),(Singular: M),(Parallel: a,b | 1 to M),(Singular: s)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>), ('s', <class 'str'>)]
 tenka1-2012-qualA-D                      OK                   [(Singular: N),(Parallel: c | 0 to N-1)] [('N', <class 'int'>), ('c', <class 'str'>)]
 tenka1-2012-qualB-A                      OK                   [(Singular: a),(Singular: b),(Singular: c)] [('a', <class 'int'>), ('b', <class 'int'>), ('c', <class 'int'>)]
-tenka1-2012-qualB-B                      No result
+tenka1-2012-qualB-B                      OK                   [(Singular: c)] [('c', <class 'str'>)]
 tenka1-2012-qualB-C                      OK                   [(Singular: N),(Parallel: Ts,Te | 1 to N)] [('N', <class 'int'>), ('Ts', <class 'str'>), ('Te', <class 'str'>)]
 tenka1-2012-qualB-D                      OK                   [(Singular: H),(Singular: W),(Parallel: c | 0 to H-1)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>)]
 tenka1-2012-qualC-A                      OK                   [(Singular: n)] [('n', <class 'int'>)]
@@ -7009,13 +7009,13 @@ tenka1-2014-final-open-C                 OK                   [(Singular: N),(Pa
 tenka1-2014-final-open-D                 OK                   [(Singular: T),(Parallel: n,k | 1 to T)] [('T', <class 'int'>), ('n', <class 'int'>), ('k', <class 'int'>)]
 tenka1-2014-final-open-E                 OK                   [(Singular: S),(Singular: Q),(Parallel: a,b | 1 to Q)] [('S', <class 'str'>), ('Q', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
 tenka1-2014-quala-A                      No result
-tenka1-2014-quala-B                      No result
+tenka1-2014-quala-B                      OK                   [(Singular: S)] [('S', <class 'str'>)]
 tenka1-2014-quala-C                      OK                   [(Singular: n),(Singular: m),(Parallel: P | 1 to n)] [('n', <class 'int'>), ('m', <class 'int'>), ('P', <class 'str'>)]
 tenka1-2014-quala-D                      OK                   [(Singular: N),(TwoDimensional: X),(TwoDimensional: Y)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>)]
-tenka1-2014-quala-E                      No result
+tenka1-2014-quala-E                      OK                   [(Singular: H),(Singular: W),(Parallel: c | 1 to H),(Singular: Q),(Parallel: x,y | 1 to Q)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'str'>), ('Q', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 tenka1-2014-qualb-A                      OK                   [(Singular: S)] [('S', <class 'str'>)]
 tenka1-2014-qualb-B                      OK                   [(Singular: N),(Singular: S),(Parallel: T | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>), ('T', <class 'str'>)]
-tenka1-2014-qualb-C                      No result
+tenka1-2014-qualb-C                      OK                   [(Singular: N),(Parallel: C | 1 to N)] [('N', <class 'int'>), ('C', <class 'str'>)]
 tenka1-2014-qualb-E                      OK                   [(Singular: L),(Singular: N),(Singular: M),(Parallel: K | 1 to L),(Parallel: A,S | 1 to N)] [('L', <class 'int'>), ('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'float'>), ('A', <class 'int'>), ('S', <class 'float'>)]
 tenka1-2015-final-A                      No result
 tenka1-2015-final-B                      OK                   [(Singular: V),(Singular: E),(Singular: K),(Parallel: a,b | 1 to E)] [('V', <class 'int'>), ('E', <class 'int'>), ('K', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
@@ -7067,7 +7067,7 @@ tenka1-2017-beginner-C                   OK                   [(Singular: N)] [(
 tenka1-2017-beginner-D                   OK                   [(Singular: N),(Singular: K),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 tenka1-2018-C                            OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 tenka1-2018-D                            OK                   [(Singular: N)] [('N', <class 'int'>)]
-tenka1-2018-E                            No result
+tenka1-2018-E                            OK                   [(Singular: H),(Singular: W),(Parallel: s | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('s', <class 'str'>)]
 tenka1-2018-F                            OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 tenka1-2018-beginner-A                   OK                   [(Singular: S)] [('S', <class 'str'>)]
 tenka1-2018-beginner-B                   OK                   [(Singular: A),(Singular: B),(Singular: K)] [('A', <class 'int'>), ('B', <class 'int'>), ('K', <class 'int'>)]
@@ -7314,7 +7314,7 @@ utpc2012-I                               OK                   [(Singular: W),(Si
 utpc2012-J                               No result
 utpc2012-K                               OK                   [(Singular: a),(Singular: b)] [('a', <class 'int'>), ('b', <class 'int'>)]
 utpc2012-L                               No result
-utpc2013-A                               No result
+utpc2013-A                               OK                   [(Singular: s)] [('s', <class 'str'>)]
 utpc2013-B                               OK                   [(Singular: Y),(Singular: M)] [('Y', <class 'int'>), ('M', <class 'int'>)]
 utpc2013-C                               No result
 utpc2013-D                               OK                   [(Singular: N),(Parallel: A | 0 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>)]
@@ -7356,7 +7356,7 @@ utpc2021-C                               OK                   [(Singular: N),(Pa
 utpc2021-D                               OK                   [(Singular: N),(Parallel: A,B | 1 to N-1)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 utpc2021-E                               OK                   [(Singular: N),(Singular: K),(Parallel: x,y,c | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('c', <class 'int'>)]
 utpc2021-F                               OK                   [(Singular: N),(Parallel: k | 1 to 2),(Parallel: h | 1 to N)] [('N', <class 'int'>), ('k', <class 'int'>), ('h', <class 'int'>)]
-utpc2021-G                               No result
+utpc2021-G                               OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'int'>)]
 utpc2021-H                               OK                   [(Singular: N),(Singular: A),(Singular: B)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 utpc2021-I                               OK                   [(Singular: N),(Singular: M),(TwoDimensional: a)] [('N', <class 'int'>), ('M', <class 'int'>), ('a', <class 'int'>)]
 utpc2021-J                               OK                   [(Singular: N)] [('N', <class 'int'>)]
@@ -7431,7 +7431,7 @@ waipc-qual-A                             OK                   [RepeatedCase: pre
 waipc-qual-B                             No result
 waipc-qual-C                             OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Parallel: A,B,X,Y | 1 to N-1)]] [('T', <class 'int'>)]
 waipc-qual-D                             OK                   [RepeatedCase: prefix=[(Singular: T)], count=T, case=[(Singular: N),(Singular: M),(Parallel: A,B | 1 to M)]] [('T', <class 'int'>)]
-waipc-qual-E                             No result
+waipc-qual-E                             OK                   [(Singular: N),(Singular: M),(TwoDimensional: A)] [('N', <class 'int'>), ('M', <class 'int'>), ('A', <class 'int'>)]
 waipc-qual-F                             OK                   [(Singular: N),(Singular: M),(Singular: K)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>)]
 waipc-qual-G                             OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 wn2017_1-A                               No result
@@ -7467,16 +7467,16 @@ wtf22-day2-open-B                        OK                   [(Singular: N),(Si
 wtf22-day2-open-C                        OK                   [(Singular: N),(Singular: L),(Parallel: C,V | 1 to N)] [('N', <class 'int'>), ('L', <class 'int'>), ('C', <class 'int'>), ('V', <class 'int'>)]
 wtf22-day2-open-D                        OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
 wtf22-day2-open-E                        OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]
-wupc2012-B                               No result
+wupc2012-B                               OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 wupc2012-C                               No result
 wupc2012-D                               No result
 wupc2012-E                               No result
-wupc2012-F                               No result
-wupc2012-closed-B                        No result
+wupc2012-F                               OK                   [(Singular: N),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
+wupc2012-closed-B                        OK                   [(Singular: N),(Parallel: S | 1 to N)] [('N', <class 'int'>), ('S', <class 'str'>)]
 wupc2012-closed-C                        No result
 wupc2012-closed-D                        No result
 wupc2012-closed-E                        No result
-wupc2012-closed-F                        No result
+wupc2012-closed-F                        OK                   [(Singular: N),(Parallel: x,y | 1 to N)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>)]
 wupc2019-A                               No result
 wupc2019-B                               No result
 wupc2019-C                               No result
@@ -7490,7 +7490,7 @@ wupc2019-J                               No result
 wupc2nd-A                                OK                   [(Singular: N),(Singular: M)] [('N', <class 'int'>), ('M', <class 'int'>)]
 wupc2nd-D                                OK                   [(Parallel: N | 1 to 5)] [('N', <class 'int'>)]
 wupc2nd-E                                OK                   [(Singular: N),(Singular: M),(Singular: K),(Parallel: f,t,c | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('K', <class 'int'>), ('f', <class 'int'>), ('t', <class 'int'>), ('c', <class 'int'>)]
-wupc2nd-F                                No result
+wupc2nd-F                                OK                   [(Singular: N),(Singular: M),(Singular: L),(Singular: S),(Parallel: c | 1 to N)] [('N', <class 'int'>), ('M', <class 'int'>), ('L', <class 'int'>), ('S', <class 'str'>), ('c', <class 'str'>)]
 wupc2nd-G                                OK                   [(Singular: N),(Singular: M),(Singular: H),(Parallel: a | 1 to N),(Parallel: operation,arg | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('H', <class 'int'>), ('a', <class 'int'>), ('operation', <class 'str'>), ('arg', <class 'int'>)]
 wupc2nd-H                                OK                   [(Singular: N),(Singular: M),(Parallel: start,end | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('start', <class 'int'>), ('end', <class 'int'>)]
 wupc2nd-I                                OK                   [(Singular: N),(Parallel: type,x,y,size | 1 to N)] [('N', <class 'int'>), ('type', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('size', <class 'int'>)]
@@ -7500,7 +7500,7 @@ xmascon16-E                              No result
 xmascon16-F                              OK                   [(Singular: T),(Parallel: N,A,B,K | 1 to T)] [('T', <class 'int'>), ('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('K', <class 'int'>)]
 xmascon16-G                              OK                   [(Singular: N),(Singular: M),(Parallel: C | 1 to N),(Parallel: S,T,A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('C', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 xmascon16-H                              OK                   [(Singular: N),(Singular: K),(Parallel: A,B,C | 1 to N-1)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-xmascon16-I                              No result
+xmascon16-I                              OK                   [(Singular: H),(Singular: W),(Singular: I),(Singular: S),(Singular: O),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('I', <class 'int'>), ('S', <class 'int'>), ('O', <class 'int'>), ('C', <class 'str'>)]
 xmascon16-J                              OK                   [(Singular: t)] [('t', <class 'int'>)]
 xmascon16midnight-B                      No result
 xmascon16midnight-D                      OK                   [(Singular: N),(Parallel: X | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>)]
@@ -7508,7 +7508,7 @@ xmascon16midnight-E                      No result
 xmascon16midnight-F                      OK                   [(Singular: T),(Parallel: N,A,B,K | 1 to T)] [('T', <class 'int'>), ('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('K', <class 'int'>)]
 xmascon16midnight-G                      OK                   [(Singular: N),(Singular: M),(Parallel: C | 1 to N),(Parallel: S,T,A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('C', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 xmascon16midnight-H                      OK                   [(Singular: N),(Singular: K),(Parallel: A,B,C | 1 to N-1)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-xmascon16midnight-I                      No result
+xmascon16midnight-I                      OK                   [(Singular: H),(Singular: W),(Singular: I),(Singular: S),(Singular: O),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('I', <class 'int'>), ('S', <class 'int'>), ('O', <class 'int'>), ('C', <class 'str'>)]
 xmascon16midnight-J                      OK                   [(Singular: t)] [('t', <class 'int'>)]
 xmascon16noon-B                          No result
 xmascon16noon-D                          OK                   [(Singular: N),(Parallel: X | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>)]
@@ -7516,7 +7516,7 @@ xmascon16noon-E                          No result
 xmascon16noon-F                          OK                   [(Singular: T),(Parallel: N,A,B,K | 1 to T)] [('T', <class 'int'>), ('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('K', <class 'int'>)]
 xmascon16noon-G                          OK                   [(Singular: N),(Singular: M),(Parallel: C | 1 to N),(Parallel: S,T,A,B | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('C', <class 'int'>), ('S', <class 'int'>), ('T', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 xmascon16noon-H                          OK                   [(Singular: N),(Singular: K),(Parallel: A,B,C | 1 to N-1)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>), ('C', <class 'int'>)]
-xmascon16noon-I                          No result
+xmascon16noon-I                          OK                   [(Singular: H),(Singular: W),(Singular: I),(Singular: S),(Singular: O),(Parallel: C | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('I', <class 'int'>), ('S', <class 'int'>), ('O', <class 'int'>), ('C', <class 'str'>)]
 xmascon16noon-J                          OK                   [(Singular: t)] [('t', <class 'int'>)]
 xmascon17-C                              No result
 xmascon17-D                              OK                   [(Singular: N),(Singular: K),(Singular: m)] [('N', <class 'int'>), ('K', <class 'int'>), ('m', <class 'int'>)]
@@ -7533,14 +7533,14 @@ xmascon18-H                              OK                   [(Singular: S),(Si
 xmascon18-I                              OK                   [(Singular: X)] [('X', <class 'float'>)]
 xmascon18-J                              OK                   [(Singular: S)] [('S', <class 'str'>)]
 xmascon19-A                              No result
-xmascon19-B                              No result
-xmascon19-C                              No result
+xmascon19-B                              OK                   [(Singular: N),(Singular: mathrmop)] [('N', <class 'int'>), ('mathrmop', <class 'str'>)]
+xmascon19-C                              OK                   [(Singular: H),(Singular: W),(Parallel: A | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('A', <class 'str'>)]
 xmascon19-D                              OK                   [(Singular: N)] [('N', <class 'int'>)]
 xmascon19-E                              OK                   [(Singular: N)] [('N', <class 'int'>)]
-xmascon19-F                              No result
-xmascon19-G                              OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to W)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
-xmascon19-H                              No result
-xmascon19-I                              No result
+xmascon19-F                              OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+xmascon19-G                              OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+xmascon19-H                              OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
+xmascon19-I                              OK                   [(Singular: H),(Singular: W),(Parallel: S | 1 to H)] [('H', <class 'int'>), ('W', <class 'int'>), ('S', <class 'str'>)]
 xmascon19-J                              OK                   [(Singular: N),(Parallel: A,B | 1 to N)] [('N', <class 'int'>), ('A', <class 'str'>), ('B', <class 'str'>)]
 xmascon19-K                              OK                   [(Singular: N),(Parallel: P | 1 to N)] [('N', <class 'int'>), ('P', <class 'int'>)]
 xmascon19-L                              No result
@@ -7556,7 +7556,7 @@ xmascon20-I                              OK                   [(Singular: M),(Si
 xmascon21-A                              No result
 xmascon21-B                              OK                   [(Singular: M),(Singular: N)] [('M', <class 'int'>), ('N', <class 'int'>)]
 xmascon21-C                              OK                   [(Singular: N),(Singular: S)] [('N', <class 'int'>), ('S', <class 'str'>)]
-xmascon21-D                              No result
+xmascon21-D                              OK                   [(Singular: N),(Singular: K),(ThreeDimensional: A)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 xmascon21-E                              OK                   [(Singular: K)] [('K', <class 'int'>)]
 xmascon21-F                              No result
 xmascon21-G                              No result

--- a/tests/resources/test_fmtprediction/answer.txt
+++ b/tests/resources/test_fmtprediction/answer.txt
@@ -359,7 +359,7 @@ abc079-C                                 OK                   [(Singular: ABCD)]
 abc079-D                                 OK                   [(Singular: H),(Singular: W),(TwoDimensional: c),(TwoDimensional: A)] [('H', <class 'int'>), ('W', <class 'int'>), ('c', <class 'int'>), ('A', <class 'int'>)]
 abc080-A                                 OK                   [(Singular: N),(Singular: A),(Singular: B)] [('N', <class 'int'>), ('A', <class 'int'>), ('B', <class 'int'>)]
 abc080-B                                 OK                   [(Singular: N)] [('N', <class 'int'>)]
-abc080-C                                 No result
+abc080-C                                 OK                   [(Singular: N),(ThreeDimensional: F),(TwoDimensional: P)] [('N', <class 'int'>), ('F', <class 'int'>), ('P', <class 'int'>)]
 abc080-D                                 OK                   [(Singular: N),(Singular: C),(Parallel: s,t,c | 1 to N)] [('N', <class 'int'>), ('C', <class 'int'>), ('s', <class 'int'>), ('t', <class 'int'>), ('c', <class 'int'>)]
 abc081-A                                 No result
 abc081-B                                 OK                   [(Singular: N),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('A', <class 'int'>)]

--- a/tests/resources/test_fmtprediction/answer.txt
+++ b/tests/resources/test_fmtprediction/answer.txt
@@ -4857,7 +4857,7 @@ code-festival-2015-morning-middle-C      OK                   [(Singular: N),(Pa
 code-festival-2015-morning-middle-D      OK                   [(Singular: N),(Singular: K),(Parallel: A | 1 to N)] [('N', <class 'int'>), ('K', <class 'int'>), ('A', <class 'int'>)]
 code-festival-2015-okinawa-open-A        OK                   [(Singular: H),(Singular: W),(Singular: K)] [('H', <class 'int'>), ('W', <class 'int'>), ('K', <class 'int'>)]
 code-festival-2015-okinawa-open-B        OK                   [(Singular: N),(Singular: X),(Singular: Y),(Parallel: a,b | 1 to N)] [('N', <class 'int'>), ('X', <class 'int'>), ('Y', <class 'int'>), ('a', <class 'int'>), ('b', <class 'int'>)]
-code-festival-2015-okinawa-open-C        No result
+code-festival-2015-okinawa-open-C        OK                   [(Singular: N),(TwoDimensional: c)] [('N', <class 'int'>), ('c', <class 'str'>)]
 code-festival-2015-okinawa-open-D        OK                   [(Singular: N),(Singular: M),(Parallel: p,q | 1 to M)] [('N', <class 'int'>), ('M', <class 'int'>), ('p', <class 'int'>), ('q', <class 'int'>)]
 code-festival-2015-okinawa-open-E        OK                   [(Singular: H),(Singular: W)] [('H', <class 'int'>), ('W', <class 'int'>)]
 code-festival-2015-okinawa-open-F        OK                   [(Singular: N),(Parallel: x,y | 1 to N),(Singular: x_a),(Singular: y_a),(Singular: x_b),(Singular: y_b),(Singular: x_c),(Singular: y_c)] [('N', <class 'int'>), ('x', <class 'int'>), ('y', <class 'int'>), ('x_a', <class 'int'>), ('y_a', <class 'int'>), ('x_b', <class 'int'>), ('y_b', <class 'int'>), ('x_c', <class 'int'>), ('y_c', <class 'int'>)]

--- a/tests/resources/test_three_dimensional/official_cases.json
+++ b/tests/resources/test_three_dimensional/official_cases.json
@@ -1,0 +1,96 @@
+{
+  "schema": "atcoder_tools_three_dimensional_official_cases_v1",
+  "cases": [
+    {
+      "task_id": "abc080_c",
+      "source_url": "https://atcoder.jp/contests/abc080/tasks/abc080_c",
+      "source_html_sha256": "5549587fb76e4b228e9c022b05fa3e1478efabc53f47e42667a46fb337b9b735",
+      "input_format_text": "N\n\n\nF_{1,1,1}\n \nF_{1,1,2}\n \n...\n \nF_{1,5,1}\n \nF_{1,5,2}\n\n\n:\n\n\nF_{N,1,1}\n \nF_{N,1,2}\n \n...\n \nF_{N,5,1}\n \nF_{N,5,2}\n\n\nP_{1,0}\n \n...\n \nP_{1,10}\n\n\n:\n\n\nP_{N,0}\n \n...\n \nP_{N,10}",
+      "input_format_blocks": [
+        "N\n\n\nF_{1,1,1}\n \nF_{1,1,2}\n \n...\n \nF_{1,5,1}\n \nF_{1,5,2}\n\n\n:\n\n\nF_{N,1,1}\n \nF_{N,1,2}\n \n...\n \nF_{N,5,1}\n \nF_{N,5,2}\n\n\nP_{1,0}\n \n...\n \nP_{1,10}\n\n\n:\n\n\nP_{N,0}\n \n...\n \nP_{N,10}"
+      ],
+      "input_format_context_text": "入力\n入力は以下の形式で標準入力から与えられる。\nN\nF_{1,1,1}\nF_{1,1,2}\n...\nF_{1,5,1}\nF_{1,5,2}\n:\nF_{N,1,1}\nF_{N,1,2}\n...\nF_{N,5,1}\nF_{N,5,2}\nP_{1,0}\n...\nP_{1,10}\n:\nP_{N,0}\n...\nP_{N,10}",
+      "sample_inputs": [
+        "1\n1 1 0 1 0 0 0 1 0 1\n3 4 5 6 7 8 9 -2 -3 4 -2",
+        "2\n1 1 1 1 1 0 0 0 0 0\n0 0 0 0 0 1 1 1 1 1\n0 -2 -2 -2 -2 -2 -1 -1 -1 -1 -1\n0 -2 -2 -2 -2 -2 -1 -1 -1 -1 -1",
+        "3\n1 1 1 1 1 1 0 0 1 1\n0 1 0 1 1 1 1 0 1 0\n1 0 1 1 0 1 0 1 0 1\n-8 6 -2 -8 -8 4 8 7 -6 2 2\n-9 2 0 1 7 -5 0 -2 -6 5 5\n6 -6 7 -9 6 -5 8 0 -9 -7 -7"
+      ],
+      "expected_patterns": {
+        "F": "ThreeDimensionalPattern",
+        "P": "TwoDimensionalPattern"
+      },
+      "expected_variables": {
+        "N": {
+          "type": "Type.int",
+          "dim_num": 0
+        },
+        "F": {
+          "type": "Type.int",
+          "dim_num": 3
+        },
+        "P": {
+          "type": "Type.int",
+          "dim_num": 2
+        }
+      }
+    },
+    {
+      "task_id": "abc322_d",
+      "source_url": "https://atcoder.jp/contests/abc322/tasks/abc322_d",
+      "source_html_sha256": "b035bdb077eb9e3ac132aa7065bfa552437aa0abae017804872fdd79e5c8fe02",
+      "input_format_text": "P_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}\n\n\nP_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}\n\n\nP_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}\n\n\nP_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}\n\n\nP_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}\n\n\nP_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}\n\n\nP_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}\n\n\nP_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}\n\n\nP_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}\n\n\nP_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}\n\n\nP_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}\n\n\nP_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}",
+      "input_format_blocks": [
+        "P_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}\n\n\nP_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}\n\n\nP_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}\n\n\nP_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}\n\n\nP_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}\n\n\nP_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}\n\n\nP_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}\n\n\nP_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}\n\n\nP_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}\n\n\nP_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}\n\n\nP_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}\n\n\nP_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}"
+      ],
+      "input_format_context_text": "入力\n入力は以下の形式で標準入力から与えられる。\nP_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}\nP_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}\nP_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}\nP_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}\nP_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}\nP_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}\nP_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}\nP_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}\nP_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}\nP_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}\nP_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}\nP_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}",
+      "sample_inputs": [
+        "....\n###.\n.#..\n....\n....\n.###\n.##.\n....\n..#.\n.##.\n.##.\n.##.",
+        "###.\n#.#.\n##..\n....\n....\n..#.\n....\n....\n####\n##..\n#...\n#...",
+        "##..\n#..#\n####\n....\n....\n##..\n.##.\n....\n.#..\n.#..\n.#..\n.#..",
+        "....\n..#.\n....\n....\n....\n..#.\n....\n....\n....\n..#.\n....\n....",
+        "....\n####\n#...\n#...\n....\n####\n...#\n..##\n....\n..##\n..#.\n..##",
+        "###.\n.##.\n..#.\n.###\n....\n...#\n..##\n...#\n....\n#...\n#...\n#..."
+      ],
+      "expected_patterns": {
+        "P": "TwoDimensionalPattern"
+      },
+      "expected_variables": {
+        "P": {
+          "type": "Type.str",
+          "dim_num": 2
+        }
+      }
+    },
+    {
+      "task_id": "abc366_d",
+      "source_url": "https://atcoder.jp/contests/abc366/tasks/abc366_d",
+      "source_html_sha256": "0d97770abeb4742a6b0ca038a93622d982ba42e9cd90cca521f4c67d3cd732bc",
+      "input_format_text": "N\n\n\nA_{1,1,1}\n \nA_{1,1,2}\n \n\\ldots\n \nA_{1,1,N}\n\n\nA_{1,2,1}\n \nA_{1,2,2}\n \n\\ldots\n \nA_{1,2,N}\n\n\n\\vdots\n\n\nA_{1,N,1}\n \nA_{1,N,2}\n \n\\ldots\n \nA_{1,N,N}\n\n\nA_{2,1,1}\n \nA_{2,1,2}\n \n\\ldots\n \nA_{2,1,N}\n\n\nA_{2,2,1}\n \nA_{2,2,2}\n \n\\ldots\n \nA_{2,2,N}\n\n\n\\vdots\n\n\nA_{2,N,1}\n \nA_{2,N,2}\n \n\\ldots\n \nA_{2,N,N}\n\n\n\\vdots\n\n\nA_{N,1,1}\n \nA_{N,1,2}\n \n\\ldots\n \nA_{N,1,N}\n\n\nA_{N,2,1}\n \nA_{N,2,2}\n \n\\ldots\n \nA_{N,2,N}\n\n\n\\vdots\n\n\nA_{N,N,1}\n \nA_{N,N,2}\n \n\\ldots\n \nA_{N,N,N}\n\n\nQ\n\n\nLx_1\n \nRx_1\n \nLy_1\n \nRy_1\n \nLz_1\n \nRz_1\n\n\nLx_2\n \nRx_2\n \nLy_2\n \nRy_2\n \nLz_2\n \nRz_2\n\n\n\\vdots\n\n\nLx_Q\n \nRx_Q\n \nLy_Q\n \nRy_Q\n \nLz_Q\n \nRz_Q",
+      "input_format_blocks": [
+        "N\n\n\nA_{1,1,1}\n \nA_{1,1,2}\n \n\\ldots\n \nA_{1,1,N}\n\n\nA_{1,2,1}\n \nA_{1,2,2}\n \n\\ldots\n \nA_{1,2,N}\n\n\n\\vdots\n\n\nA_{1,N,1}\n \nA_{1,N,2}\n \n\\ldots\n \nA_{1,N,N}\n\n\nA_{2,1,1}\n \nA_{2,1,2}\n \n\\ldots\n \nA_{2,1,N}\n\n\nA_{2,2,1}\n \nA_{2,2,2}\n \n\\ldots\n \nA_{2,2,N}\n\n\n\\vdots\n\n\nA_{2,N,1}\n \nA_{2,N,2}\n \n\\ldots\n \nA_{2,N,N}\n\n\n\\vdots\n\n\nA_{N,1,1}\n \nA_{N,1,2}\n \n\\ldots\n \nA_{N,1,N}\n\n\nA_{N,2,1}\n \nA_{N,2,2}\n \n\\ldots\n \nA_{N,2,N}\n\n\n\\vdots\n\n\nA_{N,N,1}\n \nA_{N,N,2}\n \n\\ldots\n \nA_{N,N,N}\n\n\nQ\n\n\nLx_1\n \nRx_1\n \nLy_1\n \nRy_1\n \nLz_1\n \nRz_1\n\n\nLx_2\n \nRx_2\n \nLy_2\n \nRy_2\n \nLz_2\n \nRz_2\n\n\n\\vdots\n\n\nLx_Q\n \nRx_Q\n \nLy_Q\n \nRy_Q\n \nLz_Q\n \nRz_Q"
+      ],
+      "input_format_context_text": "入力\n入力は以下の形式で標準入力から与えられる。\nN\nA_{1,1,1}\nA_{1,1,2}\n\\ldots\nA_{1,1,N}\nA_{1,2,1}\nA_{1,2,2}\n\\ldots\nA_{1,2,N}\n\\vdots\nA_{1,N,1}\nA_{1,N,2}\n\\ldots\nA_{1,N,N}\nA_{2,1,1}\nA_{2,1,2}\n\\ldots\nA_{2,1,N}\nA_{2,2,1}\nA_{2,2,2}\n\\ldots\nA_{2,2,N}\n\\vdots\nA_{2,N,1}\nA_{2,N,2}\n\\ldots\nA_{2,N,N}\n\\vdots\nA_{N,1,1}\nA_{N,1,2}\n\\ldots\nA_{N,1,N}\nA_{N,2,1}\nA_{N,2,2}\n\\ldots\nA_{N,2,N}\n\\vdots\nA_{N,N,1}\nA_{N,N,2}\n\\ldots\nA_{N,N,N}\nQ\nLx_1\nRx_1\nLy_1\nRy_1\nLz_1\nRz_1\nLx_2\nRx_2\nLy_2\nRy_2\nLz_2\nRz_2\n\\vdots\nLx_Q\nRx_Q\nLy_Q\nRy_Q\nLz_Q\nRz_Q",
+      "sample_inputs": [
+        "2\n1 2\n3 4\n5 6\n7 8\n2\n1 2 2 2 1 1\n2 2 1 2 1 2",
+        "3\n733 857 714\n956 208 257\n123 719 648\n840 881 245\n245 112 746\n306 942 694\n58 870 849\n13 208 789\n687 906 783\n8\n3 3 3 3 1 1\n1 3 2 3 3 3\n2 2 2 3 1 1\n1 3 1 1 1 1\n2 3 2 3 2 3\n1 2 1 1 1 2\n3 3 2 2 1 3\n1 2 2 3 2 3"
+      ],
+      "expected_patterns": {
+        "A": "ThreeDimensionalPattern"
+      },
+      "expected_variables": {
+        "N": {
+          "type": "Type.int",
+          "dim_num": 0
+        },
+        "A": {
+          "type": "Type.int",
+          "dim_num": 3
+        },
+        "Q": {
+          "type": "Type.int",
+          "dim_num": 0
+        }
+      }
+    }
+  ]
+}

--- a/tests/resources/test_three_dimensional/official_cases.json
+++ b/tests/resources/test_three_dimensional/official_cases.json
@@ -91,6 +91,37 @@
           "dim_num": 0
         }
       }
+    },
+    {
+      "task_id": "code_festival_2015_okinawa_c",
+      "legacy_case_ids": [
+        "code-festival-2015-okinawa-open-C"
+      ],
+      "source_url": "https://atcoder.jp/contests/code-festival-2015-okinawa-open/tasks/code_festival_2015_okinawa_c",
+      "source_html_sha256": "e4aeb4096aaba6e46a0333100e90c42458256ee37a5a6c7a4ab9a5c9604fc8b0",
+      "input_format_text": "N\nc_{1, 1, 1}c_{1, 1, 2}c_{1, 1, 3}\nc_{1, 2, 1}c_{1, 2, 2}c_{1, 2, 3}\nc_{1, 3, 1}c_{1, 3, 2}c_{1, 3, 3}\nc_{2, 1, 1}c_{2, 1, 2}c_{2, 1, 3}\nc_{2, 2, 1}c_{2, 2, 2}c_{2, 2, 3}\nc_{2, 3, 1}c_{2, 3, 2}c_{2, 3, 3}\n:\nc_{N, 1, 1}c_{N, 1, 2}c_{N, 1, 3}\nc_{N, 2, 1}c_{N, 2, 2}c_{N, 2, 3}\nc_{N, 3, 1}c_{N, 3, 2}c_{N, 3, 3}\n",
+      "input_format_blocks": [
+        "N\nc_{1, 1, 1}c_{1, 1, 2}c_{1, 1, 3}\nc_{1, 2, 1}c_{1, 2, 2}c_{1, 2, 3}\nc_{1, 3, 1}c_{1, 3, 2}c_{1, 3, 3}\nc_{2, 1, 1}c_{2, 1, 2}c_{2, 1, 3}\nc_{2, 2, 1}c_{2, 2, 2}c_{2, 2, 3}\nc_{2, 3, 1}c_{2, 3, 2}c_{2, 3, 3}\n:\nc_{N, 1, 1}c_{N, 1, 2}c_{N, 1, 3}\nc_{N, 2, 1}c_{N, 2, 2}c_{N, 2, 3}\nc_{N, 3, 1}c_{N, 3, 2}c_{N, 3, 3}\n"
+      ],
+      "input_format_context_text": "",
+      "sample_inputs": [
+        "2\n#.#\n#.#\n#.#\n###\n###\n...\n",
+        "4\n###\n###\n###\n...\n###\n###\n##.\n##.\n##.\n###\n###\n###\n",
+        "4\n###\n###\n###\n...\n###\n###\n.#.\n.#.\n.#.\n###\n###\n###\n"
+      ],
+      "expected_patterns": {
+        "c": "TwoDimensionalPattern"
+      },
+      "expected_variables": {
+        "N": {
+          "type": "Type.int",
+          "dim_num": 0
+        },
+        "c": {
+          "type": "Type.str",
+          "dim_num": 2
+        }
+      }
     }
   ]
 }

--- a/tests/test_fmtprediction_compact_digit_grid_fallback.py
+++ b/tests/test_fmtprediction_compact_digit_grid_fallback.py
@@ -1,0 +1,116 @@
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.predict_format import (
+    _collapse_compact_digit_grid_rows,
+    predict_format,
+)
+
+
+def _predict(
+    input_format,
+    sample_inputs,
+):
+    content = ProblemContent(
+        input_format_text=input_format,
+        samples=[
+            Sample(
+                sample_input,
+                "",
+            )
+            for sample_input in sample_inputs
+        ],
+        original_html="",
+    )
+
+    return str(
+        predict_format(content).format
+    )
+
+
+def test_compact_digit_grid_rows_keep_outer_index():
+    actual = _collapse_compact_digit_grid_rows(
+        (
+            "N\n"
+            "a_1 a_2 ... a_9 a_{10}\n"
+            "c_{11}c_{12}...c_{17}\n"
+            "c_{21}c_{22}...c_{27}\n"
+            "...\n"
+            "...\n"
+            "c_{N1}c_{N2}...c_{N7}\n"
+        )
+    )
+
+    assert actual == (
+        "N\n"
+        "a_1 a_2 ... a_9 a_{10}\n"
+        "c_{1}\n"
+        "c_{2}\n"
+        "...\n"
+        "...\n"
+        "c_{N}\n"
+    )
+
+
+def test_k2pc_easy_b_is_recovered():
+    actual = _predict(
+        (
+            "N\n"
+            "a_1 a_2 ... a_9 a_{10}\n"
+            "c_{11}c_{12}...c_{17}\n"
+            "c_{21}c_{22}...c_{27}\n"
+            "...\n"
+            "...\n"
+            "c_{N1}c_{N2}...c_{N7}\n"
+        ),
+        [
+            (
+                "3\n"
+                "1 1 2 1 1 1 1 1 1 3\n"
+                "-X--X-X\n"
+                "-------\n"
+                "X--X-X-\n"
+            ),
+            (
+                "2\n"
+                "1 1 1 1 1 1 1 1 1 1\n"
+                "XXXXXXX\n"
+                "-------\n"
+            ),
+        ],
+    )
+
+    assert actual == (
+        "[(Singular: N),"
+        "(Parallel: a | 1 to 10),"
+        "(Parallel: c | 1 to N)]"
+    )
+
+
+def test_space_separated_references_are_not_collapsed():
+    actual = _collapse_compact_digit_grid_rows(
+        (
+            "N\n"
+            "c_{11} c_{12} ... c_{17}\n"
+        )
+    )
+
+    assert actual == (
+        "N\n"
+        "c_{11} c_{12} ... c_{17}\n"
+    )
+
+
+def test_single_index_vector_is_not_collapsed():
+    actual = _collapse_compact_digit_grid_rows(
+        (
+            "N\n"
+            "a_1 a_2 ... a_9 a_{10}\n"
+        )
+    )
+
+    assert actual == (
+        "N\n"
+        "a_1 a_2 ... a_9 a_{10}\n"
+    )

--- a/tests/test_fmtprediction_header_bound_abstract_rows.py
+++ b/tests/test_fmtprediction_header_bound_abstract_rows.py
@@ -1,0 +1,160 @@
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+from atcodertools.fmtprediction.tokenize_format import (
+    collapse_string_runs,
+)
+
+
+def _predict(
+    input_format,
+    sample_inputs,
+):
+    content = ProblemContent(
+        input_format_text=input_format,
+        samples=[
+            Sample(
+                sample_input,
+                "",
+            )
+            for sample_input
+            in sample_inputs
+        ],
+        original_html="",
+    )
+
+    return str(
+        predict_format(content).format
+    )
+
+
+def test_generic_i_row_is_still_removed():
+    actual = collapse_string_runs(
+        (
+            "N\n"
+            "S_1\n"
+            "S_i\n"
+            "S_N\n"
+        )
+    )
+
+    assert actual == (
+        "N\n"
+        "S_1\n"
+        "S_N\n"
+    )
+
+
+def test_declared_m_endpoint_is_preserved():
+    actual = collapse_string_runs(
+        (
+            "n m Y Z\n"
+            "c_1 p_1\n"
+            "c_2 p_2\n"
+            ":\n"
+            ":\n"
+            "c_m p_m\n"
+            "b_1b_2 ‥‥ b_n\n"
+        )
+    )
+
+    assert actual == (
+        "n m Y Z\n"
+        "c_1 p_1\n"
+        "c_2 p_2\n"
+        ":\n"
+        ":\n"
+        "c_m p_m\n"
+        "b\n"
+    )
+
+
+def test_arc010_c_is_recovered():
+    actual = _predict(
+        (
+            "n m Y Z\n"
+            "c_1 p_1\n"
+            "c_2 p_2\n"
+            ":\n"
+            ":\n"
+            "c_m p_m\n"
+            "b_1b_2 ‥‥ b_n\n"
+        ),
+        [
+            (
+                "5 3 3 5\n"
+                "R 1\n"
+                "G 1\n"
+                "B 1\n"
+                "RGBRR\n"
+            ),
+            (
+                "3 3 3 5\n"
+                "R 1\n"
+                "G 1\n"
+                "B 1\n"
+                "RGB\n"
+            ),
+        ],
+    )
+
+    assert actual == (
+        "[(Singular: n),"
+        "(Singular: m),"
+        "(Singular: Y),"
+        "(Singular: Z),"
+        "(Parallel: c,p | 1 to m),"
+        "(Singular: b)]"
+    )
+
+
+def test_declared_r_grid_endpoint_is_preserved():
+    actual = collapse_string_runs(
+        (
+            "r c\n"
+            "C_{1,1}C_{1,2} ... C_{1,c}\n"
+            ":\n"
+            "C_{r,1}C_{r,2} ... C_{r,c}\n"
+        )
+    )
+
+    assert actual == (
+        "r c\n"
+        "C_{1}\n"
+        ":\n"
+        "C_{r}\n"
+    )
+
+
+def test_soundhound_grid_is_recovered():
+    actual = _predict(
+        (
+            "r c\n"
+            "C_{1,1}C_{1,2} ... C_{1,c}\n"
+            ":\n"
+            "C_{r,1}C_{r,2} ... C_{r,c}\n"
+        ),
+        [
+            (
+                "3 3\n"
+                "...\n"
+                "...\n"
+                "...\n"
+            ),
+            (
+                "2 4\n"
+                "abcd\n"
+                "efgh\n"
+            ),
+        ],
+    )
+
+    assert actual == (
+        "[(Singular: r),"
+        "(Singular: c),"
+        "(Parallel: C | 1 to r)]"
+    )

--- a/tests/test_fmtprediction_spaced_string_grid_fallback.py
+++ b/tests/test_fmtprediction_spaced_string_grid_fallback.py
@@ -1,0 +1,104 @@
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.predict_format import (
+    _collapse_spaced_grid_rows,
+    predict_format,
+)
+
+
+def _predict(
+    input_format,
+    sample_inputs,
+):
+    content = ProblemContent(
+        input_format_text=input_format,
+        samples=[
+            Sample(
+                sample_input,
+                "",
+            )
+            for sample_input
+            in sample_inputs
+        ],
+        original_html="",
+    )
+
+    return str(
+        predict_format(content).format
+    )
+
+
+def test_spaced_grid_rows_collapse_outer_index():
+    actual = _collapse_spaced_grid_rows(
+        (
+            "H W\n"
+            "c_{0,0} c_{0,1} c_{0,W-1}\n"
+            "c_{1,0} c_{1,1} c_{1,W-1}\n"
+            ":\n"
+            "c_{H-1,0} c_{H-1,1} c_{H-1,W-1}\n"
+        )
+    )
+
+    assert actual == (
+        "H W\n"
+        "c_{0}\n"
+        "c_{1}\n"
+        ":\n"
+        "c_{H-1}\n"
+    )
+
+
+def test_atc001_a_is_recovered():
+    actual = _predict(
+        (
+            "H W\n"
+            "c_{0,0} c_{0,1} c_{0,W-1}\n"
+            "c_{1,0} c_{1,1} c_{1,W-1}\n"
+            ":\n"
+            "c_{H-1,0} c_{H-1,1} c_{H-1,W-1}\n"
+        ),
+        [
+            (
+                "4 5\n"
+                "s####\n"
+                "....#\n"
+                "#####\n"
+                "#...g\n"
+            ),
+            (
+                "3 4\n"
+                "s...\n"
+                ".##.\n"
+                "...g\n"
+            ),
+        ],
+    )
+
+    assert actual == (
+        "[(Singular: H),"
+        "(Singular: W),"
+        "(Parallel: c | 0 to H-1)]"
+    )
+
+
+def test_numeric_grid_keeps_two_dimensions():
+    actual = _predict(
+        (
+            "H W\n"
+            "a_{0,0} a_{0,1} a_{0,W-1}\n"
+            "a_{1,0} a_{1,1} a_{1,W-1}\n"
+            ":\n"
+            "a_{H-1,0} a_{H-1,1} a_{H-1,W-1}\n"
+        ),
+        [
+            (
+                "2 3\n"
+                "1 2 3\n"
+                "4 5 6\n"
+            )
+        ],
+    )
+
+    assert "TwoDimensional: a" in actual

--- a/tests/test_fmtprediction_structural_string_grid.py
+++ b/tests/test_fmtprediction_structural_string_grid.py
@@ -1,0 +1,129 @@
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+
+
+def _predict(
+    input_format,
+    sample_inputs,
+):
+    content = ProblemContent(
+        input_format_text=input_format,
+        samples=[
+            Sample(
+                sample_input,
+                "",
+            )
+            for sample_input
+            in sample_inputs
+        ],
+        original_html="",
+    )
+
+    return str(
+        predict_format(content).format
+    )
+
+
+def test_square_grid_uses_outer_index_structure():
+    actual = _predict(
+        (
+            "H W\n"
+            "s_{1, 1} s_{1, 2} "
+            "... s_{1, W}\n"
+            "s_{2, 1} s_{2, 2} "
+            "... s_{2, W}\n"
+            ":\n"
+            "s_{H, 1} s_{H, 2} "
+            "... s_{H, W}\n"
+        ),
+        [
+            (
+                "3 3\n"
+                "#..\n"
+                ".#.\n"
+                "..#\n"
+            )
+        ],
+    )
+
+    assert actual == (
+        "[(Singular: H),"
+        "(Singular: W),"
+        "(Parallel: s | 1 to H)]"
+    )
+
+
+def test_glued_square_grid_uses_outer_index():
+    actual = _predict(
+        (
+            "H W K\n"
+            "A_{1,1}A_{1,2}...A_{1,W}\n"
+            ":\n"
+            "A_{H,1}A_{H,2}...A_{H,W}\n"
+        ),
+        [
+            (
+                "3 3 2\n"
+                "S..\n"
+                ".#.\n"
+                "..#\n"
+            )
+        ],
+    )
+
+    assert actual == (
+        "[(Singular: H),"
+        "(Singular: W),"
+        "(Singular: K),"
+        "(Parallel: A | 1 to H)]"
+    )
+
+
+def test_ldots_grid_becomes_string_rows():
+    actual = _predict(
+        (
+            "H W\n"
+            "a_{1, 1}\\ldotsa_{1, W}\n"
+            ":\n"
+            "a_{H, 1}\\ldotsa_{H, W}\n"
+        ),
+        [
+            (
+                "3 4\n"
+                "...#\n"
+                ".#..\n"
+                "....\n"
+            )
+        ],
+    )
+
+    assert actual == (
+        "[(Singular: H),"
+        "(Singular: W),"
+        "(Parallel: a | 1 to H)]"
+    )
+
+
+def test_numeric_grid_is_not_string_collapsed():
+    actual = _predict(
+        (
+            "H W\n"
+            "a_{1,1} a_{1,2} ... a_{1,W}\n"
+            ":\n"
+            "a_{H,1} a_{H,2} ... a_{H,W}\n"
+        ),
+        [
+            (
+                "2 3\n"
+                "1 2 3\n"
+                "4 5 6\n"
+            )
+        ],
+    )
+
+    assert "TwoDimensional: a" in actual

--- a/tests/test_multi_case_wrapper_preference.py
+++ b/tests/test_multi_case_wrapper_preference.py
@@ -1,0 +1,136 @@
+import unittest
+
+from atcodertools.fmtprediction.predict_format import (
+    MultiCaseFormatPrediction,
+    _prefer_explicit_wrapper_candidates,
+)
+
+
+class _FakeVariable:
+    def __init__(self, name, dimension):
+        self.name = name
+        self._dimension = dimension
+
+    def dim_num(self):
+        return self._dimension
+
+
+class _FakeFormat:
+    def __init__(self, text, variables):
+        self._text = text
+        self._variables = variables
+
+    def __str__(self):
+        return self._text
+
+    def all_vars(self):
+        return list(self._variables)
+
+
+class TestMultiCaseWrapperPreference(
+    unittest.TestCase
+):
+    def prediction(
+        self,
+        prefix,
+        case,
+        layout,
+    ):
+        return MultiCaseFormatPrediction(
+            prefix,
+            case,
+            "T",
+            {},
+            layout,
+        )
+
+    def test_wrapper_beats_case_placeholder_split(
+        self,
+    ):
+        count = _FakeVariable("T", 0)
+
+        placeholder = _FakeVariable(
+            "mathrmcase",
+            1,
+        )
+
+        case = _FakeFormat(
+            "[(Singular: N)]",
+            [_FakeVariable("N", 0)],
+        )
+
+        wrapper = self.prediction(
+            _FakeFormat(
+                "[(Singular: T)]",
+                [count],
+            ),
+            case,
+            "wrapper",
+        )
+
+        split = self.prediction(
+            _FakeFormat(
+                (
+                    "[(Singular: T),"
+                    "(Parallel: mathrmcase "
+                    "| 1 to T)]"
+                ),
+                [count, placeholder],
+            ),
+            case,
+            "split",
+        )
+
+        self.assertEqual(
+            [wrapper],
+            _prefer_explicit_wrapper_candidates(
+                [split, wrapper]
+            ),
+        )
+
+    def test_real_split_array_is_preserved(
+        self,
+    ):
+        count = _FakeVariable("T", 0)
+
+        real_array = _FakeVariable(
+            "A",
+            1,
+        )
+
+        case = _FakeFormat(
+            "[(Singular: N)]",
+            [_FakeVariable("N", 0)],
+        )
+
+        wrapper = self.prediction(
+            _FakeFormat(
+                "[(Singular: T)]",
+                [count],
+            ),
+            case,
+            "wrapper",
+        )
+
+        split = self.prediction(
+            _FakeFormat(
+                (
+                    "[(Singular: T),"
+                    "(Parallel: A | 1 to T)]"
+                ),
+                [count, real_array],
+            ),
+            case,
+            "split",
+        )
+
+        self.assertEqual(
+            [split, wrapper],
+            _prefer_explicit_wrapper_candidates(
+                [split, wrapper]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_three_dimensional_codegen.py
+++ b/tests/test_three_dimensional_codegen.py
@@ -1,0 +1,225 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from atcodertools.codegen.code_generators.universal_code_generator import (
+    UniversalCodeGenerator,
+    get_builtin_code_generator_info_toml_path,
+)
+from atcodertools.codegen.code_style_config import CodeStyleConfig
+from atcodertools.codegen.models.code_gen_args import CodeGenArgs
+from atcodertools.common.language import PYTHON
+from atcodertools.constprediction.models.problem_constant_set import (
+    ProblemConstantSet,
+)
+from atcodertools.fmtprediction.models.format import (
+    Format,
+    SingularPattern,
+    ThreeDimensionalPattern,
+)
+from atcodertools.fmtprediction.models.index import Index
+from atcodertools.fmtprediction.models.type import Type
+from atcodertools.fmtprediction.models.variable import Variable
+
+
+def make_index(maximum):
+    index = Index()
+    index.update("1")
+    index.update(maximum)
+    return index
+
+
+def make_three_dimensional_format():
+    format_ = Format()
+
+    for name in ("D", "H", "W"):
+        format_.push_back(
+            SingularPattern(
+                Variable(
+                    name,
+                    None,
+                    None,
+                    Type.int,
+                )
+            )
+        )
+
+    array = Variable(
+        "A",
+        make_index("D"),
+        make_index("H"),
+        Type.int,
+        third_index=make_index("W"),
+    )
+
+    format_.push_back(
+        ThreeDimensionalPattern(array)
+    )
+
+    return format_
+
+
+class TestThreeDimensionalCodeGenerator(unittest.TestCase):
+    def setUp(self):
+        self.format = make_three_dimensional_format()
+        self.config = CodeStyleConfig(
+            lang=PYTHON.name
+        )
+        self.toml_path = (
+            get_builtin_code_generator_info_toml_path(
+                PYTHON.name
+            )
+        )
+
+    def generate_parameters(self):
+        generator = UniversalCodeGenerator(
+            self.format,
+            self.config,
+            self.toml_path,
+        )
+
+        return generator.generate_parameters()
+
+    def test_three_dimensional_parameters(self):
+        parameters = self.generate_parameters()
+
+        self.assertEqual(
+            "D, H, W, A",
+            parameters["actual_arguments"],
+        )
+        self.assertIn(
+            'A: "List[List[List[int]]]"',
+            parameters["formal_arguments"],
+        )
+
+        combined = parameters[
+            "input_part_with_solve_function"
+        ]
+
+        self.assertIn(
+            "range(D)",
+            combined,
+        )
+        self.assertIn(
+            "range(H)",
+            combined,
+        )
+        self.assertIn(
+            "range(W)",
+            combined,
+        )
+        self.assertIn(
+            "solve(D, H, W, A)",
+            combined,
+        )
+
+    def test_generated_python_executes(self):
+        template = "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import sys",
+                "",
+                (
+                    'def solve(D: int, H: int, W: int, '
+                    'A: "List[List[List[int]]]"):'
+                ),
+                (
+                    "    print("
+                    "D, H, W, A[1][0][2], "
+                    "sum("
+                    "value "
+                    "for plane in A "
+                    "for row in plane "
+                    "for value in row"
+                    ")"
+                    ")"
+                ),
+                "",
+                "def main():",
+                "    def iterate_tokens():",
+                "        for line in sys.stdin:",
+                "            for word in line.split():",
+                "                yield word",
+                "",
+                "    tokens = iterate_tokens()",
+                "    {{ input_part_with_solve_function }}",
+                "",
+                "",
+                "if __name__ == '__main__':",
+                "    main()",
+                "",
+            ]
+        )
+
+        code = PYTHON.default_code_generator(
+            CodeGenArgs(
+                template=template,
+                format_=self.format,
+                constants=ProblemConstantSet(),
+                config=self.config,
+            )
+        )
+
+        sample_input = (
+            "2 2 3\n"
+            "1 2 3\n"
+            "4 5 6\n"
+            "7 8 9\n"
+            "10 11 12\n"
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(
+                directory,
+                "main.py",
+            )
+
+            with open(
+                path,
+                "w",
+                encoding="utf-8",
+            ) as file:
+                file.write(code)
+
+            compile_result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "py_compile",
+                    path,
+                ],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(
+                0,
+                compile_result.returncode,
+                compile_result.stderr,
+            )
+
+            run_result = subprocess.run(
+                [
+                    sys.executable,
+                    path,
+                ],
+                input=sample_input,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(
+                0,
+                run_result.returncode,
+                run_result.stderr,
+            )
+            self.assertEqual(
+                "2 2 3 9 78\n",
+                run_result.stdout,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_three_dimensional_codegen.py
+++ b/tests/test_three_dimensional_codegen.py
@@ -94,10 +94,47 @@ class TestThreeDimensionalCodeGenerator(unittest.TestCase):
             parameters["formal_arguments"],
         )
 
-        combined = parameters[
-            "input_part_with_solve_function"
-        ]
+        for key in (
+            "multi_case",
+            "input_part",
+            "prefix_input_part",
+            "case_input_part",
+            "case_count_var",
+            "case_loop_var",
+        ):
+            self.assertIn(
+                key,
+                parameters,
+            )
 
+        self.assertFalse(
+            parameters["multi_case"]
+        )
+        self.assertIsNone(
+            parameters["case_count_var"]
+        )
+        self.assertIsNone(
+            parameters["case_loop_var"]
+        )
+        self.assertNotIn(
+            "input_part_with_solve_function",
+            parameters,
+        )
+        self.assertNotIn(
+            "input_part_with_solve_function_nested",
+            parameters,
+        )
+
+        combined = parameters["input_part"]
+
+        self.assertEqual(
+            combined,
+            parameters["prefix_input_part"],
+        )
+        self.assertEqual(
+            combined,
+            parameters["case_input_part"],
+        )
         self.assertIn(
             "range(D)",
             combined,
@@ -110,8 +147,8 @@ class TestThreeDimensionalCodeGenerator(unittest.TestCase):
             "range(W)",
             combined,
         )
-        self.assertIn(
-            "solve(D, H, W, A)",
+        self.assertNotIn(
+            "solve(",
             combined,
         )
 
@@ -144,7 +181,16 @@ class TestThreeDimensionalCodeGenerator(unittest.TestCase):
                 "                yield word",
                 "",
                 "    tokens = iterate_tokens()",
-                "    {{ input_part_with_solve_function }}",
+                "    {% if multi_case %}",
+                (
+                    "    raise AssertionError("
+                    "'unexpected multi-case format'"
+                    ")"
+                ),
+                "    {% else %}",
+                "    {{ input_part }}",
+                "    solve({{ actual_arguments }})",
+                "    {% endif %}",
                 "",
                 "",
                 "if __name__ == '__main__':",

--- a/tests/test_three_dimensional_compact_rows.py
+++ b/tests/test_three_dimensional_compact_rows.py
@@ -1,0 +1,224 @@
+import subprocess
+import sys
+import unittest
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.codegen.code_generators.universal_code_generator import (
+    UniversalCodeGenerator,
+    get_builtin_code_generator_info_toml_path,
+)
+from atcodertools.codegen.code_style_config import CodeStyleConfig
+from atcodertools.common.language import PYTHON
+from atcodertools.fmtprediction.models.format import (
+    ThreeDimensionalPattern,
+    TwoDimensionalPattern,
+)
+from atcodertools.fmtprediction.models.type import Type
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+
+
+FIXED_COMPACT_FORMAT = """
+P_{1,1,1}P_{1,1,2}P_{1,1,3}P_{1,1,4}
+P_{1,2,1}P_{1,2,2}P_{1,2,3}P_{1,2,4}
+P_{1,3,1}P_{1,3,2}P_{1,3,3}P_{1,3,4}
+P_{1,4,1}P_{1,4,2}P_{1,4,3}P_{1,4,4}
+P_{2,1,1}P_{2,1,2}P_{2,1,3}P_{2,1,4}
+P_{2,2,1}P_{2,2,2}P_{2,2,3}P_{2,2,4}
+P_{2,3,1}P_{2,3,2}P_{2,3,3}P_{2,3,4}
+P_{2,4,1}P_{2,4,2}P_{2,4,3}P_{2,4,4}
+P_{3,1,1}P_{3,1,2}P_{3,1,3}P_{3,1,4}
+P_{3,2,1}P_{3,2,2}P_{3,2,3}P_{3,2,4}
+P_{3,3,1}P_{3,3,2}P_{3,3,3}P_{3,3,4}
+P_{3,4,1}P_{3,4,2}P_{3,4,3}P_{3,4,4}
+""".strip()
+
+FIXED_COMPACT_SAMPLE = """
+####
+....
+#...
+.#..
+..#.
+...#
+##..
+..##
+#.#.
+.#.#
+###.
+...#
+""".strip()
+
+VARIABLE_COMPACT_FORMAT = r"""
+D H W
+A_{1,1,1}A_{1,1,2}\ldots A_{1,1,W}
+A_{1,2,1}A_{1,2,2}\ldots A_{1,2,W}
+\vdots
+A_{1,H,1}A_{1,H,2}\ldots A_{1,H,W}
+\vdots
+A_{D,H,1}A_{D,H,2}\ldots A_{D,H,W}
+""".strip()
+
+VARIABLE_COMPACT_SAMPLE = """
+2 2 3
+.#.
+###
+..#
+#..
+""".strip()
+
+VARIABLE_SPACED_FORMAT = r"""
+D H W
+A_{1,1,1} A_{1,1,2} \ldots A_{1,1,W}
+A_{1,2,1} A_{1,2,2} \ldots A_{1,2,W}
+\vdots
+A_{1,H,1} A_{1,H,2} \ldots A_{1,H,W}
+\vdots
+A_{D,H,1} A_{D,H,2} \ldots A_{D,H,W}
+""".strip()
+
+VARIABLE_SPACED_SAMPLE = """
+2 2 3
+. # .
+# # #
+. . #
+# . .
+""".strip()
+
+
+def content(input_format, sample_input):
+    return ProblemContent(
+        input_format_text=input_format,
+        input_format_blocks=[input_format],
+        input_format_context_text="",
+        original_html="",
+        samples=[Sample(sample_input, "")],
+    )
+
+
+class TestThreeDimensionalCompactRows(unittest.TestCase):
+    def test_fixed_compact_rows_collapse_innermost_dimension(self):
+        result = predict_format(
+            content(
+                FIXED_COMPACT_FORMAT,
+                FIXED_COMPACT_SAMPLE,
+            )
+        )
+
+        self.assertEqual(1, len(result.format.sequence))
+        pattern = result.format.sequence[0]
+
+        self.assertIsInstance(
+            pattern,
+            TwoDimensionalPattern,
+        )
+        self.assertEqual("P", pattern.var.name)
+        self.assertEqual(Type.str, pattern.var.type)
+        self.assertEqual(2, pattern.var.dim_num())
+
+    def test_variable_compact_rows_collapse_innermost_dimension(self):
+        result = predict_format(
+            content(
+                VARIABLE_COMPACT_FORMAT,
+                VARIABLE_COMPACT_SAMPLE,
+            )
+        )
+        pattern = result.format.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            TwoDimensionalPattern,
+        )
+        self.assertEqual("A", pattern.var.name)
+        self.assertEqual(Type.str, pattern.var.type)
+        self.assertEqual(2, pattern.var.dim_num())
+
+    def test_spaced_character_elements_remain_three_dimensional(self):
+        result = predict_format(
+            content(
+                VARIABLE_SPACED_FORMAT,
+                VARIABLE_SPACED_SAMPLE,
+            )
+        )
+        pattern = result.format.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            ThreeDimensionalPattern,
+        )
+        self.assertEqual("A", pattern.var.name)
+        self.assertEqual(Type.str, pattern.var.type)
+        self.assertEqual(3, pattern.var.dim_num())
+
+    def test_generated_python_reads_compact_rows(self):
+        result = predict_format(
+            content(
+                FIXED_COMPACT_FORMAT,
+                FIXED_COMPACT_SAMPLE,
+            )
+        )
+
+        generator = UniversalCodeGenerator(
+            result.format,
+            CodeStyleConfig(
+                lang=PYTHON.name
+            ),
+            get_builtin_code_generator_info_toml_path(
+                PYTHON.name
+            ),
+        )
+        parameters = generator.generate_parameters()
+
+        self.assertIn(
+            "List[List[str]]",
+            parameters["formal_arguments"],
+        )
+
+        generated = "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "from typing import *",
+                "import sys",
+                "",
+                "def solve(P):",
+                (
+                    "    print("
+                    "len(P), len(P[0]), P[0][0]"
+                    ")"
+                ),
+                "",
+                "tokens = iter(sys.stdin.read().split())",
+                parameters["input_part"],
+                "solve(P)",
+                "",
+            ]
+        )
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                generated,
+            ],
+            input=FIXED_COMPACT_SAMPLE,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(
+            0,
+            completed.returncode,
+            msg=completed.stderr + "\n" + generated,
+        )
+        self.assertEqual(
+            "3 4 ####",
+            completed.stdout.strip(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_three_dimensional_official_cases.py
+++ b/tests/test_three_dimensional_official_cases.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+import unittest
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "resources"
+    / "test_three_dimensional"
+    / "official_cases.json"
+)
+
+
+class TestThreeDimensionalOfficialCases(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(
+            FIXTURE_PATH.read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def _content(self, case):
+        return ProblemContent(
+            input_format_text=case[
+                "input_format_text"
+            ],
+            input_format_blocks=case[
+                "input_format_blocks"
+            ],
+            input_format_context_text=case[
+                "input_format_context_text"
+            ],
+            original_html="",
+            samples=[
+                Sample(sample_input, "")
+                for sample_input
+                in case["sample_inputs"]
+            ],
+        )
+
+    def test_fixture_schema_and_count(self):
+        self.assertEqual(
+            (
+                "atcoder_tools_three_dimensional_"
+                "official_cases_v1"
+            ),
+            self.fixture["schema"],
+        )
+        self.assertEqual(
+            3,
+            len(self.fixture["cases"]),
+        )
+        self.assertEqual(
+            {
+                "abc080_c",
+                "abc322_d",
+                "abc366_d",
+            },
+            {
+                case["task_id"]
+                for case in self.fixture["cases"]
+            },
+        )
+
+    def test_official_prediction_contracts(self):
+        for case in self.fixture["cases"]:
+            with self.subTest(
+                task_id=case["task_id"]
+            ):
+                result = predict_format(
+                    self._content(case)
+                )
+                format_ = result.format
+
+                variables = {
+                    variable.name: variable
+                    for variable in format_.all_vars()
+                }
+
+                pattern_classes = {}
+
+                for pattern in format_.sequence:
+                    for variable in pattern.all_vars():
+                        pattern_classes[
+                            variable.name
+                        ] = type(pattern).__name__
+
+                for name, expected in case[
+                    "expected_variables"
+                ].items():
+                    self.assertIn(
+                        name,
+                        variables,
+                    )
+                    variable = variables[name]
+
+                    self.assertEqual(
+                        expected["type"],
+                        str(variable.type),
+                    )
+                    self.assertEqual(
+                        expected["dim_num"],
+                        variable.dim_num(),
+                    )
+
+                for name, expected_class in case[
+                    "expected_patterns"
+                ].items():
+                    self.assertEqual(
+                        expected_class,
+                        pattern_classes[name],
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_three_dimensional_official_cases.py
+++ b/tests/test_three_dimensional_official_cases.py
@@ -56,7 +56,7 @@ class TestThreeDimensionalOfficialCases(unittest.TestCase):
             self.fixture["schema"],
         )
         self.assertEqual(
-            3,
+            4,
             len(self.fixture["cases"]),
         )
         self.assertEqual(
@@ -64,6 +64,7 @@ class TestThreeDimensionalOfficialCases(unittest.TestCase):
                 "abc080_c",
                 "abc322_d",
                 "abc366_d",
+                "code_festival_2015_okinawa_c",
             },
             {
                 case["task_id"]

--- a/tests/test_three_dimensional_prediction.py
+++ b/tests/test_three_dimensional_prediction.py
@@ -1,0 +1,121 @@
+import unittest
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.client.models.sample import Sample
+from atcodertools.fmtprediction.models.format import (
+    ThreeDimensionalPattern,
+)
+from atcodertools.fmtprediction.models.type import Type
+from atcodertools.fmtprediction.predict_format import (
+    predict_format,
+)
+from atcodertools.fmtprediction.predict_simple_format import (
+    predict_simple_format,
+)
+from atcodertools.fmtprediction.tokenize_format import (
+    search_formats_with_minimum_vars,
+)
+
+
+INPUT_FORMAT = """
+D H W
+A_{1,1,1} ... A_{1,1,W}
+A_{1,H,1} ... A_{1,H,W}
+...
+A_{D,1,1} ... A_{D,1,W}
+A_{D,H,1} ... A_{D,H,W}
+"""
+
+SAMPLE_INPUT = """
+2 2 3
+1 2 3
+4 5 6
+7 8 9
+10 11 12
+"""
+
+
+class TestThreeDimensionalPrediction(unittest.TestCase):
+    def test_tokenizer_finds_three_indices(self):
+        candidates = (
+            search_formats_with_minimum_vars(
+                INPUT_FORMAT
+            )
+        )
+
+        matching = [
+            candidate
+            for candidate in candidates
+            if any(
+                token.var_name == "A"
+                and token.dim_num() == 3
+                and token.first_index == "1"
+                and token.second_index == "1"
+                and token.third_index == "1"
+                for token in candidate.var_tokens
+            )
+        ]
+
+        self.assertTrue(matching)
+
+    def test_simple_format_contains_3d_pattern(self):
+        candidates = (
+            search_formats_with_minimum_vars(
+                INPUT_FORMAT
+            )
+        )
+
+        tokenized = next(
+            candidate
+            for candidate in candidates
+            if any(
+                token.var_name == "A"
+                and token.dim_num() == 3
+                for token in candidate.var_tokens
+            )
+        )
+
+        format_ = predict_simple_format(
+            tokenized.var_tokens
+        )
+
+        pattern = format_.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            ThreeDimensionalPattern,
+        )
+        self.assertEqual(3, pattern.var.dim_num())
+
+    def test_end_to_end_type_prediction(self):
+        content = ProblemContent(
+            INPUT_FORMAT,
+            [Sample(SAMPLE_INPUT, None)],
+        )
+
+        result = predict_format(content)
+        format_ = result.format
+        pattern = format_.sequence[-1]
+
+        self.assertIsInstance(
+            pattern,
+            ThreeDimensionalPattern,
+        )
+        self.assertEqual(
+            ["D", "H", "W", "A"],
+            [
+                variable.name
+                for variable in format_.all_vars()
+            ],
+        )
+        self.assertEqual(Type.int, pattern.var.type)
+        self.assertEqual(3, pattern.var.dim_num())
+        self.assertIsNotNone(
+            pattern.var.third_index
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

PR #314 の入力形式予測改善を、PR #258との同一corpus比較で判明した不足も含めて整理・拡張します。

> このPRは3次元配列対応の #318 に依存します。  
> #318がstableへマージされるまでは、GitHub上の差分に3D対応も含まれます。  
> #318のマージ後は、本PR固有の入力形式予測改善だけが差分として残ります。

## 主な変更

- 連結・ドット区切り文字列および文字グリッドのcollapse
- LaTeX区切り記号・空白の正規化
- 累乗演算子 `^` の解析
- `A_0 ... A_{2^N-1}` のような配列長を推定
- 文字グリッドの外側次元を構造から正しく選択
- 宣言済み終端添字を抽象行として誤削除しない
- 空白区切り文字グリッドへの限定フォールバック
- `c_{11}c_{12}...c_{17}` 型の複合数字添字を行文字列として推定
- corpus期待値と専用回帰テストを追加

## corpus結果

### #318適用後との比較

- #318 branch: 2,019 / 2,279 OK
- このPR: 2,108 / 2,279 OK
- 新規成功: 89件
- 既存成功からの退行: 0件
- 意図した予測構造修正: 7件

### stableからの合計

- stable: 2,017 / 2,279 OK
- #318＋このPR: 2,108 / 2,279 OK
- 合計新規成功: 91件
- 合計退行: 0件

## PR #258との差分検証

PR #314だけでは拾えなかった、PR #258-onlyの次の5件もすべて回収しています。

- abc076-C
- arc010-C
- atc001-A
- k2pc-easy-B
- soundhound2018-C

## 予測構造の修正

次の7件について、文字列・文字グリッドの外側次元を修正しています。

- abc096-C
- agc014-C
- arc007-C
- cf17-final-H
- cf17-final-open-H
- digitalarts2012-B
- dp-H

## 検証

- fmtprediction / multi-case / 3D関連テスト: PASS
- 変更Pythonファイルの構文検査: PASS
- flake8: PASS
- `git diff --check`: PASS
- corpus 2,279件回帰: PASS
- worktree: clean

関連: #314, #258, #318
