### PR TITLE
入力形式を保持するlossless表現を追加

### DIFF
--- a/atcodertools/fmtprediction/models/input_specification.py
+++ b/atcodertools/fmtprediction/models/input_specification.py
@@ -1,0 +1,283 @@
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Tuple
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+
+
+class InputTokenKind(Enum):
+    WORD = "word"
+    INTEGER = "integer"
+    ELLIPSIS = "ellipsis"
+    DELIMITER = "delimiter"
+    SYMBOL = "symbol"
+
+
+@dataclass(frozen=True)
+class InputToken:
+    raw_text: str
+    normalized_text: str
+    kind: InputTokenKind
+
+
+@dataclass(frozen=True)
+class InputLine:
+    raw_text: str
+    tokens: Tuple[InputToken, ...]
+
+
+@dataclass(frozen=True)
+class InputBlock:
+    raw_text: str
+    lines: Tuple[InputLine, ...]
+
+
+@dataclass(frozen=True)
+class InputSpecification:
+    blocks: Tuple[InputBlock, ...]
+    context_text: str
+
+    @classmethod
+    def from_problem_content(
+        cls,
+        content: ProblemContent,
+    ) -> "InputSpecification":
+        blocks = content.get_input_format_blocks()
+
+        if not blocks:
+            input_format = content.get_input_format()
+
+            if input_format is not None:
+                blocks = [input_format]
+
+        return cls(
+            blocks=tuple(
+                parse_input_block(block)
+                for block in blocks
+            ),
+            context_text=(
+                content.get_input_format_context()
+            ),
+        )
+
+
+_LATEX_WORD = re.compile(
+    r"""
+    \\(?:
+        mathrm
+        |text
+        |operatorname
+        |rm
+        |it
+    )
+    \s*
+    \{
+        [^{}]*
+    \}
+    (?:
+        _
+        (?:
+            \{[^{}]*\}
+            |[A-Za-z0-9]+
+        )
+    )?
+    """,
+    re.VERBOSE,
+)
+
+_INDEXED_WORD = re.compile(
+    r"""
+    [A-Za-z][A-Za-z0-9]*
+    (?:
+        _
+        (?:
+            \{[^{}]*\}
+            |\([^()]*\)
+            |[A-Za-z0-9]+
+        )
+    )?
+    """,
+    re.VERBOSE,
+)
+
+_INTEGER = re.compile(
+    r"[+-]?[0-9]+"
+)
+
+_ELLIPSIS = re.compile(
+    r"""
+    \\(?:
+        ldots
+        |cdots
+        |dots
+        |vdots
+        |ddots
+    )
+    |\.\.\.
+    |…
+    |‥
+    """,
+    re.VERBOSE,
+)
+
+_DELIMITER = re.compile(
+    r"[:,;=()\[\],]"
+)
+
+_TOKEN = re.compile(
+    "|".join(
+        (
+            "(?P<LATEX_WORD>{})".format(
+                _LATEX_WORD.pattern
+            ),
+            "(?P<ELLIPSIS>{})".format(
+                _ELLIPSIS.pattern
+            ),
+            "(?P<INTEGER>{})".format(
+                _INTEGER.pattern
+            ),
+            "(?P<WORD>{})".format(
+                _INDEXED_WORD.pattern
+            ),
+            "(?P<DELIMITER>{})".format(
+                _DELIMITER.pattern
+            ),
+            r"(?P<SYMBOL>\S)",
+        )
+    ),
+    re.VERBOSE,
+)
+
+_LATEX_WORD_NORMALIZER = re.compile(
+    r"""
+    \\(?:
+        mathrm
+        |text
+        |operatorname
+        |rm
+        |it
+    )
+    \s*
+    \{
+        (?P<name>[^{}]*)
+    \}
+    (?P<index>
+        (?:
+            _
+            (?:
+                \{[^{}]*\}
+                |[A-Za-z0-9]+
+            )
+        )?
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _normalize_latex_word(
+    raw_text: str,
+) -> str:
+    match = _LATEX_WORD_NORMALIZER.fullmatch(
+        raw_text
+    )
+
+    if match is None:
+        return raw_text
+
+    return "{}{}".format(
+        match.group("name"),
+        match.group("index"),
+    )
+
+
+def _make_token(
+    match,
+) -> InputToken:
+    raw_text = match.group(0)
+    group = match.lastgroup
+
+    if group == "LATEX_WORD":
+        return InputToken(
+            raw_text=raw_text,
+            normalized_text=(
+                _normalize_latex_word(raw_text)
+            ),
+            kind=InputTokenKind.WORD,
+        )
+
+    if group == "ELLIPSIS":
+        return InputToken(
+            raw_text=raw_text,
+            normalized_text="...",
+            kind=InputTokenKind.ELLIPSIS,
+        )
+
+    if group == "INTEGER":
+        return InputToken(
+            raw_text=raw_text,
+            normalized_text=raw_text,
+            kind=InputTokenKind.INTEGER,
+        )
+
+    if group == "WORD":
+        return InputToken(
+            raw_text=raw_text,
+            normalized_text=raw_text,
+            kind=InputTokenKind.WORD,
+        )
+
+    if group == "DELIMITER":
+        return InputToken(
+            raw_text=raw_text,
+            normalized_text=raw_text,
+            kind=InputTokenKind.DELIMITER,
+        )
+
+    return InputToken(
+        raw_text=raw_text,
+        normalized_text=raw_text,
+        kind=InputTokenKind.SYMBOL,
+    )
+
+
+def tokenize_input_line(
+    line: str,
+) -> Tuple[InputToken, ...]:
+    return tuple(
+        _make_token(match)
+        for match in _TOKEN.finditer(line)
+    )
+
+
+def parse_input_block(
+    block: str,
+) -> InputBlock:
+    return InputBlock(
+        raw_text=block,
+        lines=tuple(
+            InputLine(
+                raw_text=line,
+                tokens=tokenize_input_line(line),
+            )
+            for line in block.splitlines()
+        ),
+    )
+
+
+def normalized_token_lines(
+    specification: InputSpecification,
+) -> List[List[List[str]]]:
+    return [
+        [
+            [
+                token.normalized_text
+                for token in line.tokens
+            ]
+            for line in block.lines
+        ]
+        for block in specification.blocks
+    ]

--- a/tests/test_lossless_input_specification.py
+++ b/tests/test_lossless_input_specification.py
@@ -1,0 +1,267 @@
+import unittest
+
+from atcodertools.client.models.problem_content import (
+    ProblemContent,
+)
+from atcodertools.fmtprediction.models.input_specification import (
+    InputSpecification,
+    InputTokenKind,
+    normalized_token_lines,
+)
+
+
+class TestLosslessInputSpecification(
+    unittest.TestCase
+):
+    def test_preserves_query_block_boundaries_and_tags(
+        self,
+    ):
+        content = ProblemContent(
+            input_format_text=(
+                "N Q\n"
+                "A_1 A_2 \\ldots A_N\n"
+                "\\text{query}_1\n"
+                "\\text{query}_2\n"
+                "\\vdots\n"
+                "\\text{query}_Q\n"
+            ),
+            input_format_blocks=[
+                (
+                    "N Q\n"
+                    "A_1 A_2 \\ldots A_N\n"
+                    "\\text{query}_1\n"
+                    "\\text{query}_2\n"
+                    "\\vdots\n"
+                    "\\text{query}_Q\n"
+                ),
+                "1 c\n",
+                "2 l r\n",
+            ],
+            input_format_context_text=(
+                "各クエリは以下のいずれかの"
+                "形式で与えられる。"
+            ),
+            samples=[],
+        )
+
+        specification = (
+            InputSpecification.from_problem_content(
+                content
+            )
+        )
+
+        self.assertEqual(
+            3,
+            len(specification.blocks),
+        )
+
+        self.assertEqual(
+            [
+                ["1", "c"],
+            ],
+            normalized_token_lines(
+                specification
+            )[1],
+        )
+
+        self.assertEqual(
+            [
+                ["2", "l", "r"],
+            ],
+            normalized_token_lines(
+                specification
+            )[2],
+        )
+
+        first_variant = (
+            specification.blocks[1]
+            .lines[0]
+            .tokens
+        )
+
+        self.assertEqual(
+            InputTokenKind.INTEGER,
+            first_variant[0].kind,
+        )
+
+        self.assertEqual(
+            "1",
+            first_variant[0].raw_text,
+        )
+
+    def test_preserves_string_tag_candidates(
+        self,
+    ):
+        content = ProblemContent(
+            input_format_text=(
+                "Q\n"
+                "operation_1\n"
+                "\\vdots\n"
+                "operation_Q\n"
+            ),
+            input_format_blocks=[
+                (
+                    "Q\n"
+                    "operation_1\n"
+                    "\\vdots\n"
+                    "operation_Q\n"
+                ),
+                "Push x\n",
+                "Pop\n",
+                "Top\n",
+            ],
+            samples=[],
+        )
+
+        specification = (
+            InputSpecification.from_problem_content(
+                content
+            )
+        )
+
+        normalized = normalized_token_lines(
+            specification
+        )
+
+        self.assertEqual(
+            [["Push", "x"]],
+            normalized[1],
+        )
+
+        self.assertEqual(
+            [["Pop"]],
+            normalized[2],
+        )
+
+        self.assertEqual(
+            InputTokenKind.WORD,
+            specification.blocks[1]
+            .lines[0]
+            .tokens[0]
+            .kind,
+        )
+
+    def test_preserves_ragged_row_boundaries(
+        self,
+    ):
+        block = (
+            "N\n"
+            "M_1\n"
+            "A_{1,1} \\ldots A_{1,M_1}\n"
+            "\\vdots\n"
+            "M_N\n"
+            "A_{N,1} \\ldots A_{N,M_N}\n"
+        )
+
+        content = ProblemContent(
+            input_format_text=block,
+            samples=[],
+        )
+
+        specification = (
+            InputSpecification.from_problem_content(
+                content
+            )
+        )
+
+        self.assertEqual(
+            1,
+            len(specification.blocks),
+        )
+
+        self.assertEqual(
+            6,
+            len(specification.blocks[0].lines),
+        )
+
+        third_line = (
+            specification.blocks[0]
+            .lines[2]
+            .tokens
+        )
+
+        self.assertEqual(
+            [
+                "A_{1,1}",
+                "...",
+                "A_{1,M_1}",
+            ],
+            [
+                token.normalized_text
+                for token in third_line
+            ],
+        )
+
+        self.assertEqual(
+            InputTokenKind.ELLIPSIS,
+            third_line[1].kind,
+        )
+
+    def test_preserves_raw_tex_and_normalizes_word(
+        self,
+    ):
+        content = ProblemContent(
+            input_format_text=(
+                "\\mathrm{query}_i : 1 c\n"
+            ),
+            samples=[],
+        )
+
+        specification = (
+            InputSpecification.from_problem_content(
+                content
+            )
+        )
+
+        tokens = (
+            specification.blocks[0]
+            .lines[0]
+            .tokens
+        )
+
+        self.assertEqual(
+            "\\mathrm{query}_i",
+            tokens[0].raw_text,
+        )
+
+        self.assertEqual(
+            "query_i",
+            tokens[0].normalized_text,
+        )
+
+        self.assertEqual(
+            InputTokenKind.DELIMITER,
+            tokens[1].kind,
+        )
+
+    def test_falls_back_to_legacy_input_format(
+        self,
+    ):
+        content = ProblemContent(
+            input_format_text=(
+                "N\n"
+                "A_1 \\ldots A_N\n"
+            ),
+            input_format_blocks=[],
+            samples=[],
+        )
+
+        specification = (
+            InputSpecification.from_problem_content(
+                content
+            )
+        )
+
+        self.assertEqual(
+            1,
+            len(specification.blocks),
+        )
+
+        self.assertEqual(
+            2,
+            len(specification.blocks[0].lines),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

入力形式を、既存の予測処理へ渡す前に情報を失わず保持するための基盤を追加します。

現在の通常の入力形式予測では、後段のtokenizerで改行が空白へ平坦化され、数値tag・文字tag候補・ブロック境界なども通常の変数列へ落とし込まれます。

本PRでは既存予測経路を変更せず、将来の行依存入力対応に利用するlossless表現だけを追加します。

## 追加内容

- `InputSpecification`
  - 複数の入力形式blockを保持
  - block内の改行を`InputLine`として保持
  - 周辺の`input_format_context_text`を保持
- `InputToken`
  - raw表記と正規化後表記を両方保持
  - word
  - integer
  - ellipsis
  - delimiter
  - symbol
- TeX表記
  - `\mathrm{query}_i`などのraw表記を保持
  - 正規化後は`query_i`として参照可能
- legacy fixture
  - 複数blockがない場合は従来の`input_format_text`へfallback

## このPRでは行わないこと

- 既存の`predict_format`への接続
- 既存の予測結果の変更
- ragged arrayの予測
- tagged queryの予測
- コード生成の変更

これらは後続PRで段階的に追加する予定です。

## 想定する後続用途

- 行ごとに長さが異なる配列
- 長さ変数を同じ行に持つ入力
- 数値・文字列tag付きクエリ
- 1操作が複数行にまたがる入力

## テスト

- lossless表現の専用テスト5件: PASS
- 既存fmtprediction corpus回帰: PASS
- multi-case関連テスト: PASS
- 3次元入力関連テスト: PASS
- flake8: PASS
- `git diff --check`: PASS

既存予測経路からは参照していないため、本PR単体では生成結果を変更しません。
